### PR TITLE
Add TypeScript MCP server for TP-Link Omada controllers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    jq \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,19 @@
+# Devcontainer usage
+
+The repository ships with a devcontainer configuration tailored for working on the Omada MCP server. The development container is based on the official TypeScript/Node.js image and launches a sidecar TP-Link Omada controller using the [`mbentley/omada-controller`](https://hub.docker.com/r/mbentley/omada-controller) image.
+
+## Services
+
+- **development** – Node.js workspace where the MCP server runs.
+- **omada** – Omada controller accessible on https://localhost:8043 and http://localhost:8088.
+
+## Getting started
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Open the repository in VS Code and run **Dev Containers: Reopen in Container**.
+3. Once the container is running, the Omada controller becomes available on the forwarded ports and npm dependencies are installed automatically.
+
+> **Tip**
+> The development service automatically sets `OMADA_BASE_URL=https://omada:8043`, enabling local integration with the controller sidecar.
+
+Use `npm run dev` inside the container to launch the MCP server in watch mode.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "TP-Link Omada MCP",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "development",
+  "workspaceFolder": "/workspace",
+  "features": {},
+  "forwardPorts": [8043, 8088],
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "typescript.tsdk": "/usr/local/share/nvm/versions/node/v20.16.0/lib/node_modules/typescript/lib"
+      },
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "biomejs.biome"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.9'
+
+services:
+  development:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    depends_on:
+      - omada
+    environment:
+      OMADA_BASE_URL: https://omada:8043
+    networks:
+      - omada
+
+  omada:
+    image: mbentley/omada-controller:latest
+    restart: unless-stopped
+    environment:
+      MANAGE_HTTP_PORT: 8088
+      MANAGE_HTTPS_PORT: 8043
+      SHOW_SERVER_LOGS: 'true'
+      SSL_CERT_NAME: omada
+      TZ: UTC
+    ports:
+      - '8043:8043'
+      - '8088:8088'
+    networks:
+      - omada
+
+networks:
+  omada:
+    driver: bridge

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  env: {
+    node: true,
+    es2022: true
+  },
+  plugins: ['@typescript-eslint', 'import'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/typescript',
+    'prettier'
+  ],
+  rules: {
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true }
+      }
+    ],
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface']
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.env
+.vscode/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
-# tplink-omada-mcp
-MCP server for TP-Link Omada
+# TP-Link Omada MCP server
+
+A Model Context Protocol (MCP) server implemented in TypeScript that exposes the TP-Link Omada controller APIs to AI copilots and automation workflows. The server authenticates against a controller, lists sites, devices, and connected clients, and offers a generic tool to invoke arbitrary Omada API endpoints.
+
+## Features
+
+- Secure login to Omada controllers with automatic token refresh
+- Tools for retrieving sites, network devices, and connected clients
+- Generic Omada API invoker for advanced automation scenarios
+- Environment-driven configuration
+- Ready-to-use devcontainer with a companion Omada controller service
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 20 or later
+- npm 9 or later
+- Access to a TP-Link Omada controller (for example using the `mbentley/omada-controller` Docker image)
+
+### Installation
+
+```bash
+npm install
+```
+
+### Configuration
+
+The MCP server reads its configuration from environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `OMADA_BASE_URL` | Base URL of the Omada controller, e.g. `https://localhost:8043` |
+| `OMADA_USERNAME` | Controller username |
+| `OMADA_PASSWORD` | Controller password |
+| `OMADA_SITE_ID` | Optional default site identifier used when a tool call does not specify one |
+| `OMADA_STRICT_SSL` | Set to `false` to allow self-signed TLS certificates |
+| `OMADA_TIMEOUT` | Optional request timeout in milliseconds |
+| `OMADA_PROXY_URL` | Optional HTTPS proxy URL for outbound requests |
+
+Create a `.env` file (ignored by git) or export the variables before launching the server.
+
+### Development
+
+```bash
+npm run dev
+```
+
+The dev mode keeps the TypeScript server running with live reload support via `tsx`.
+
+### Building
+
+```bash
+npm run build
+```
+
+### Linting
+
+```bash
+npm run lint
+```
+
+### Running the MCP server
+
+```bash
+npm start
+```
+
+The MCP server communicates over standard input and output. Integrate it with MCP-compatible clients by referencing the `npm start` command and providing the required environment variables.
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `omada.listSites` | Lists all sites configured on the controller. |
+| `omada.listDevices` | Lists provisioned devices for a given site. |
+| `omada.listClients` | Lists active client devices for a site. |
+| `omada.getDevice` | Fetches details for a specific Omada device. |
+| `omada.getClient` | Fetches details for a specific client device. |
+| `omada.callApi` | Executes a raw API request using the established Omada session. |
+
+## Devcontainer support
+
+The repository includes a ready-to-use [devcontainer](https://containers.dev/) configuration with a dedicated Omada controller sidecar for local development and testing. See [`.devcontainer/README.md`](.devcontainer/README.md) for details.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "tplink-omada-mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol server that exposes TP-Link Omada controller APIs",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write .",
+    "check": "npm run lint",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "keywords": [
+    "mcp",
+    "tp-link",
+    "omada"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.1.0",
+    "axios": "^1.7.7",
+    "https-proxy-agent": "^7.0.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "prettier": "^3.3.3",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  baseUrl: z.string().url({ message: 'OMADA_BASE_URL must be a valid URL' }),
+  username: z.string().min(1, 'OMADA_USERNAME is required'),
+  password: z.string().min(1, 'OMADA_PASSWORD is required'),
+  siteId: z.string().min(1).optional(),
+  strictSsl: z
+    .union([z.literal('true'), z.literal('false')])
+    .optional()
+    .transform((value) => value !== 'false'),
+  requestTimeout: z
+    .string()
+    .transform((value) => (value ? Number.parseInt(value, 10) : undefined))
+    .pipe(z.number().positive().optional()),
+  proxyUrl: z.string().url().optional()
+});
+
+export interface EnvironmentConfig {
+  baseUrl: string;
+  username: string;
+  password: string;
+  siteId?: string;
+  strictSsl: boolean;
+  requestTimeout?: number;
+  proxyUrl?: string;
+}
+
+export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): EnvironmentConfig {
+  const parsed = envSchema.safeParse({
+    baseUrl: env.OMADA_BASE_URL,
+    username: env.OMADA_USERNAME,
+    password: env.OMADA_PASSWORD,
+    siteId: env.OMADA_SITE_ID,
+    strictSsl: env.OMADA_STRICT_SSL,
+    requestTimeout: env.OMADA_TIMEOUT,
+    proxyUrl: env.OMADA_PROXY_URL
+  });
+
+  if (!parsed.success) {
+    const messages = parsed.error.issues.map((issue) => issue.message);
+    throw new Error(`Invalid environment configuration:\n${messages.join('\n')}`);
+  }
+
+  return {
+    baseUrl: parsed.data.baseUrl.replace(/\/$/, ''),
+    username: parsed.data.username,
+    password: parsed.data.password,
+    siteId: parsed.data.siteId,
+    strictSsl: parsed.data.strictSsl ?? true,
+    requestTimeout: parsed.data.requestTimeout,
+    proxyUrl: parsed.data.proxyUrl
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,15 @@
+import { loadConfigFromEnv } from './config.js';
+import { OmadaClient } from './omadaClient.js';
+import { startServer } from './server.js';
+
+async function main(): Promise<void> {
+  const config = loadConfigFromEnv();
+  const client = new OmadaClient(config);
+  await startServer(client);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to start Omada MCP server: ${message}`);
+  process.exitCode = 1;
+});

--- a/src/omadaClient.ts
+++ b/src/omadaClient.ts
@@ -1,0 +1,191 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import https from 'node:https';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+import { EnvironmentConfig } from './config.js';
+import {
+  ApiItemResponse,
+  ApiListResponse,
+  OmadaClientDevice,
+  OmadaDevice,
+  OmadaLoginResult,
+  OmadaSite
+} from './types.js';
+
+export interface OmadaClientOptions extends EnvironmentConfig {}
+
+function normalizeCookieHeader(values: string[] | undefined): string | undefined {
+  if (!values?.length) {
+    return undefined;
+  }
+
+  return values
+    .map((cookie) => cookie.split(';')[0])
+    .filter(Boolean)
+    .join('; ');
+}
+
+export class OmadaClient {
+  private readonly http: AxiosInstance;
+
+  private token?: string;
+
+  private cookieHeader?: string;
+
+  private readonly username: string;
+
+  private readonly password: string;
+
+  private readonly siteId?: string;
+
+  constructor(private readonly options: OmadaClientOptions) {
+    this.username = options.username;
+    this.password = options.password;
+    this.siteId = options.siteId;
+
+    const httpsAgent = options.proxyUrl
+      ? new HttpsProxyAgent(options.proxyUrl)
+      : new https.Agent({ rejectUnauthorized: options.strictSsl });
+
+    const axiosOptions: AxiosRequestConfig = {
+      baseURL: options.baseUrl,
+      httpsAgent,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      }
+    };
+
+    if (options.proxyUrl) {
+      axiosOptions.proxy = false;
+    }
+
+    if (options.requestTimeout) {
+      axiosOptions.timeout = options.requestTimeout;
+    }
+
+    this.http = axios.create(axiosOptions);
+  }
+
+  public async listSites(): Promise<OmadaSite[]> {
+    const response = await this.get<ApiListResponse<OmadaSite>>('/api/v2/sites');
+    return response.result?.data ?? [];
+  }
+
+  public async listDevices(siteId?: string): Promise<OmadaDevice[]> {
+    const response = await this.get<ApiListResponse<OmadaDevice>>(
+      `/api/v2/sites/${this.resolveSiteId(siteId)}/devices`,
+    );
+    return response.result?.data ?? [];
+  }
+
+  public async listClients(siteId?: string): Promise<OmadaClientDevice[]> {
+    const response = await this.get<ApiListResponse<OmadaClientDevice>>(
+      `/api/v2/sites/${this.resolveSiteId(siteId)}/clients`,
+    );
+    return response.result?.data ?? [];
+  }
+
+  public async getDevice(deviceId: string, siteId?: string): Promise<OmadaDevice | undefined> {
+    const response = await this.get<ApiItemResponse<OmadaDevice>>(
+      `/api/v2/sites/${this.resolveSiteId(siteId)}/devices/${deviceId}`,
+    );
+    return response.result;
+  }
+
+  public async getClient(clientId: string, siteId?: string): Promise<OmadaClientDevice | undefined> {
+    const response = await this.get<ApiItemResponse<OmadaClientDevice>>(
+      `/api/v2/sites/${this.resolveSiteId(siteId)}/clients/${clientId}`,
+    );
+    return response.result;
+  }
+
+  public async callApi<T = unknown>(config: AxiosRequestConfig): Promise<T> {
+    const response = await this.request<T>(config);
+    return response;
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    return this.request<T>({ method: 'GET', url: path });
+  }
+
+  private resolveSiteId(siteId?: string): string {
+    if (siteId) {
+      return siteId;
+    }
+
+    if (this.siteId) {
+      return this.siteId;
+    }
+
+    throw new Error('A site id must be provided either in the environment or as a parameter.');
+  }
+
+  private async ensureAuthenticated(force = false): Promise<void> {
+    if (this.token && !force) {
+      return;
+    }
+
+    const response = await this.http.post<OmadaLoginResult>(
+      '/api/v2/login',
+      {
+        username: this.username,
+        password: this.password,
+        timeout: 28800
+      },
+      { headers: { Cookie: this.cookieHeader } }
+    );
+
+    const cookie = normalizeCookieHeader(response.headers['set-cookie']);
+    if (cookie) {
+      this.cookieHeader = cookie;
+    }
+
+    if (response.data.errorCode !== 0) {
+      throw new Error(response.data.msg ?? 'Failed to authenticate with the Omada controller');
+    }
+
+    const token = response.data.result?.token;
+    if (!token) {
+      throw new Error('The Omada controller did not return an authentication token');
+    }
+
+    this.token = token;
+  }
+
+  private async request<T>(config: AxiosRequestConfig, retry = true): Promise<T> {
+    await this.ensureAuthenticated();
+
+    const requestConfig: AxiosRequestConfig = {
+      ...config,
+      headers: {
+        ...(config.headers ?? {}),
+        ...(this.cookieHeader ? { Cookie: this.cookieHeader } : {})
+      },
+      params: {
+        ...(config.params ?? {}),
+        ...(this.token ? { token: this.token } : {})
+      }
+    };
+
+    try {
+      const response = await this.http.request<T>(requestConfig);
+      return response.data;
+    } catch (error) {
+      if (!retry || !axios.isAxiosError(error)) {
+        throw error;
+      }
+
+      const status = error.response?.status;
+      const errorCode = (error.response?.data as { errorCode?: number } | undefined)?.errorCode;
+
+      if (status === 401 || errorCode === -1601 || errorCode === -1602) {
+        this.token = undefined;
+        await this.ensureAuthenticated(true);
+        return this.request<T>(config, false);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,105 @@
+import { Server } from '@modelcontextprotocol/sdk/server.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/transport/node/stdio.js';
+import { z } from 'zod';
+
+import { OmadaClient } from './omadaClient.js';
+
+const siteInputSchema = z.object({
+  siteId: z.string().min(1).optional()
+});
+
+const clientIdSchema = siteInputSchema.extend({
+  clientId: z.string().min(1)
+});
+
+const deviceIdSchema = siteInputSchema.extend({
+  deviceId: z.string().min(1)
+});
+
+const customRequestSchema = z.object({
+  method: z.string().default('GET'),
+  url: z.string().min(1, 'A controller API path is required'),
+  params: z.record(z.unknown()).optional(),
+  data: z.unknown().optional(),
+  siteId: z.string().min(1).optional()
+});
+
+function toJsonContent(value: unknown) {
+  return [{ type: 'json' as const, json: value }];
+}
+
+export async function startServer(client: OmadaClient): Promise<void> {
+  const server = new Server({
+    name: 'tplink-omada-mcp',
+    version: '0.1.0'
+  });
+
+  server.registerTool({
+    name: 'omada.listSites',
+    description: 'List all sites configured on the Omada controller.',
+    inputSchema: z.object({}),
+    handler: async () => ({
+      content: toJsonContent(await client.listSites())
+    })
+  });
+
+  server.registerTool({
+    name: 'omada.listDevices',
+    description: 'List provisioned network devices for a specific site.',
+    inputSchema: siteInputSchema,
+    handler: async (input) => ({
+      content: toJsonContent(await client.listDevices(input.siteId))
+    })
+  });
+
+  server.registerTool({
+    name: 'omada.listClients',
+    description: 'List network clients connected to a site.',
+    inputSchema: siteInputSchema,
+    handler: async (input) => ({
+      content: toJsonContent(await client.listClients(input.siteId))
+    })
+  });
+
+  server.registerTool({
+    name: 'omada.getDevice',
+    description: 'Fetch detailed information for a specific Omada device.',
+    inputSchema: deviceIdSchema,
+    handler: async (input) => ({
+      content: toJsonContent(await client.getDevice(input.deviceId, input.siteId))
+    })
+  });
+
+  server.registerTool({
+    name: 'omada.getClient',
+    description: 'Fetch details for a specific Omada client.',
+    inputSchema: clientIdSchema,
+    handler: async (input) => ({
+      content: toJsonContent(await client.getClient(input.clientId, input.siteId))
+    })
+  });
+
+  server.registerTool({
+    name: 'omada.callApi',
+    description:
+      'Call an arbitrary API path on the Omada controller. The provided URL should be a path, for example /api/v2/sites',
+    inputSchema: customRequestSchema,
+    handler: async (input) => {
+      const resolvedUrl = input.siteId
+        ? input.url.replace('{siteId}', input.siteId)
+        : input.url;
+
+      const payload = await client.callApi({
+        method: input.method,
+        url: resolvedUrl,
+        params: input.params,
+        data: input.data
+      });
+
+      return { content: toJsonContent(payload) };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,55 @@
+export interface OmadaSite {
+  id: string;
+  name: string;
+  description?: string;
+  role?: string;
+}
+
+export interface OmadaDevice {
+  id: string;
+  name: string;
+  mac: string;
+  model?: string;
+  ip?: string;
+  type?: string;
+  status?: string;
+  siteId?: string;
+}
+
+export interface OmadaClientDevice {
+  id: string;
+  name?: string;
+  mac: string;
+  ip?: string;
+  type?: string;
+  isBlocked?: boolean;
+  ssid?: string;
+  siteId?: string;
+}
+
+export interface ApiListResponse<T> {
+  errorCode: number;
+  msg?: string;
+  result?: {
+    data?: T[];
+    [key: string]: unknown;
+  };
+}
+
+export interface ApiItemResponse<T> {
+  errorCode: number;
+  msg?: string;
+  result?: T;
+}
+
+export interface OmadaLoginResult {
+  errorCode: number;
+  msg?: string;
+  result?: {
+    token?: string;
+    timeout?: number;
+    role?: string;
+    url?: string;
+    [key: string]: unknown;
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript MCP server that authenticates against Omada controllers and exposes tools for listing sites, devices, and clients
- implement an Omada API client with token management, configurable environment-driven settings, and a generic passthrough tool
- add project tooling (TypeScript config, linting, prettier) and a devcontainer with an mbentley/omada-controller sidecar

## Testing
- not run (dependency installation blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_690102fcb3a08329be9817d00a57d6ec