### PR TITLE
feat: Add client activity and most active clients tools, enhance dash…

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ If an intermediary strips the `Mcp-Session-Id` header, set `MCP_SERVER_STATEFUL=
 | `searchGlobalDevice`                | Search for devices across all accessible sites.           | Used by `searchDevices`; returns devices matching the search key globally.                           |
 | `getGridAdoptedDevicesStatByGlobal` | Query statistics for global adopted devices with filters. | Used by `listDevicesStats`; supports pagination and fuzzy search by MAC, name, model, or SN.         |
 | `getGridActiveClients`              | List active clients connected to a site.                  | Used by `listClients` and `getClient` (single client lookup is resolved from this list).             |
+| `getMostActiveClients`              | Get most active clients sorted by traffic.                | Used by `listMostActiveClients`; dashboard endpoint returning top clients by traffic usage.          |
+| `getClientActivity`                 | Get client activity statistics over time.                 | Used by `listClientsActivity`; returns time-series data of new, active, and disconnected clients.    |
 | `getOswStackDetail`                 | Retrieve details for a switch stack.                      | Used by `getSwitchStackDetail`.                                                                      |
 
 ## Devcontainer support

--- a/src/omadaClient/client.ts
+++ b/src/omadaClient/client.ts
@@ -1,4 +1,4 @@
-import type { OmadaClientInfo } from '../types/index.js';
+import type { ActiveClientInfo, ClientActivity, GetClientActivityOptions, OmadaApiResponse, OmadaClientInfo } from '../types/index.js';
 
 import type { RequestHandler } from './request.js';
 import type { SiteOperations } from './site.js';
@@ -11,7 +11,7 @@ export class ClientOperations {
         private readonly request: RequestHandler,
         private readonly site: SiteOperations,
         private readonly buildPath: (path: string) => string
-    ) {}
+    ) { }
 
     /**
      * List all clients in a site.
@@ -27,5 +27,45 @@ export class ClientOperations {
     public async getClient(identifier: string, siteId?: string): Promise<OmadaClientInfo | undefined> {
         const clients = await this.listClients(siteId);
         return clients.find((client) => client.mac === identifier || client.id === identifier);
+    }
+
+    /**
+     * Get most active clients in a site (dashboard endpoint).
+     * Returns clients sorted by total traffic.
+     *
+     * @param siteId - Optional site ID, uses default from config if not provided
+     * @returns Array of active client information
+     */
+    public async listMostActiveClients(siteId?: string): Promise<ActiveClientInfo[]> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const response = await this.request.get<OmadaApiResponse<ActiveClientInfo[]>>(
+            this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/active-clients`)
+        );
+        return response.result ?? [];
+    }
+
+    /**
+     * Get client activity statistics over time (dashboard endpoint).
+     * Returns time-series data about new, active, and disconnected clients.
+     *
+     * @param options - Options including optional siteId, start, and end timestamps
+     * @returns Array of client activity snapshots over time
+     */
+    public async listClientsActivity(options: GetClientActivityOptions = {}): Promise<ClientActivity[]> {
+        const resolvedSiteId = this.site.resolveSiteId(options.siteId);
+        const params: Record<string, unknown> = {};
+
+        if (options.start !== undefined) {
+            params.start = options.start;
+        }
+        if (options.end !== undefined) {
+            params.end = options.end;
+        }
+
+        const response = await this.request.get<OmadaApiResponse<ClientActivity[]>>(
+            this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/client-activity`),
+            params
+        );
+        return response.result ?? [];
     }
 }

--- a/src/omadaClient/index.ts
+++ b/src/omadaClient/index.ts
@@ -3,7 +3,17 @@ import https from 'node:https';
 import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 import type { EnvironmentConfig } from '../config.js';
-import type { GetDeviceStatsOptions, OmadaClientInfo, OmadaDeviceInfo, OmadaDeviceStats, OmadaSiteSummary, OswStackDetail } from '../types/index.js';
+import type {
+    ActiveClientInfo,
+    ClientActivity,
+    GetClientActivityOptions,
+    GetDeviceStatsOptions,
+    OmadaClientInfo,
+    OmadaDeviceInfo,
+    OmadaDeviceStats,
+    OmadaSiteSummary,
+    OswStackDetail,
+} from '../types/index.js';
 
 import { AuthManager } from './auth.js';
 import { ClientOperations } from './client.js';
@@ -91,6 +101,14 @@ export class OmadaClient {
 
     public async getClient(identifier: string, siteId?: string): Promise<OmadaClientInfo | undefined> {
         return this.clientOps.getClient(identifier, siteId);
+    }
+
+    public async listMostActiveClients(siteId?: string): Promise<ActiveClientInfo[]> {
+        return this.clientOps.listMostActiveClients(siteId);
+    }
+
+    public async listClientsActivity(options?: GetClientActivityOptions): Promise<ClientActivity[]> {
+        return this.clientOps.listClientsActivity(options);
     }
 
     // Generic API call

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,8 +7,10 @@ import { registerGetClientTool } from './getClient.js';
 import { registerGetDeviceTool } from './getDevice.js';
 import { registerGetSwitchStackDetailTool } from './getSwitchStackDetail.js';
 import { registerListClientsTool } from './listClients.js';
+import { registerListClientsActivityTool } from './listClientsActivity.js';
 import { registerListDevicesTool } from './listDevices.js';
 import { registerListDevicesStatsTool } from './listDevicesStats.js';
+import { registerListMostActiveClientsTool } from './listMostActiveClients.js';
 import { registerListSitesTool } from './listSites.js';
 import { registerSearchDevicesTool } from './searchDevices.js';
 
@@ -21,5 +23,7 @@ export function registerAllTools(server: McpServer, client: OmadaClient): void {
     registerGetClientTool(server, client);
     registerSearchDevicesTool(server, client);
     registerListDevicesStatsTool(server, client);
+    registerListMostActiveClientsTool(server, client);
+    registerListClientsActivityTool(server, client);
     registerCallApiTool(server, client);
 }

--- a/src/tools/listClientsActivity.ts
+++ b/src/tools/listClientsActivity.ts
@@ -1,0 +1,25 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const clientActivityInputSchema = z.object({
+    siteId: z.string().optional().describe('Optional site ID. If not provided, uses the default site from configuration.'),
+    start: z.number().int().optional().describe('Optional start timestamp in seconds (e.g., 1682000000)'),
+    end: z.number().int().optional().describe('Optional end timestamp in seconds (e.g., 1682000000)'),
+});
+
+export function registerListClientsActivityTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'listClientsActivity',
+        {
+            description:
+                'Get client activity statistics over time from the dashboard. Returns time-series data showing new, active, and disconnected clients (both wireless/EAP and wired/switch) for each time snapshot. Useful for monitoring client connection trends and activity patterns.',
+            inputSchema: clientActivityInputSchema.shape,
+        },
+        wrapToolHandler('listClientsActivity', async ({ siteId, start, end }) =>
+            toToolResult(await client.listClientsActivity({ siteId, start, end }))
+        )
+    );
+}

--- a/src/tools/listMostActiveClients.ts
+++ b/src/tools/listMostActiveClients.ts
@@ -1,0 +1,16 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerListMostActiveClientsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'listMostActiveClients',
+        {
+            description:
+                'Get the most active clients in a site, sorted by total traffic. Returns client name, MAC address, type, model, wireless status, and total traffic. This is a dashboard endpoint that provides a quick overview of top clients by traffic usage.',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('listMostActiveClients', async ({ siteId }) => toToolResult(await client.listMostActiveClients(siteId)))
+    );
+}

--- a/src/types/activeClientInfo.ts
+++ b/src/types/activeClientInfo.ts
@@ -1,0 +1,17 @@
+/**
+ * Active client information from dashboard.
+ */
+export interface ActiveClientInfo {
+    /** Client name */
+    name: string;
+    /** Whether the client is wireless */
+    wireless: boolean;
+    /** Client device type */
+    type: string;
+    /** Client device model */
+    model: string;
+    /** Client MAC address */
+    mac: string;
+    /** Total traffic in bytes */
+    totalTraffic: number;
+}

--- a/src/types/clientActivity.ts
+++ b/src/types/clientActivity.ts
@@ -1,0 +1,32 @@
+/**
+ * Client activity information from dashboard.
+ * Contains statistics about new, active, and disconnected clients over time.
+ */
+export interface ClientActivity {
+    /** Number of new wireless (EAP) clients */
+    newEapClientNum: number;
+    /** Number of new wired (switch) clients */
+    newSwitchClientNum: number;
+    /** Number of active wireless (EAP) clients */
+    activeEapClientNum: number;
+    /** Number of active wired (switch) clients */
+    activeSwitchClientNum: number;
+    /** Number of disconnected wireless (EAP) clients */
+    disconnectEapClientNum: number;
+    /** Number of disconnected wired (switch) clients */
+    disconnectSwitchClientNum: number;
+    /** Timestamp for this activity snapshot (Unix timestamp in seconds) */
+    time: number;
+}
+
+/**
+ * Options for retrieving client activity.
+ */
+export interface GetClientActivityOptions {
+    /** Optional site ID, uses default from config if not provided */
+    siteId?: string;
+    /** Optional start timestamp in seconds (e.g., 1682000000) */
+    start?: number;
+    /** Optional end timestamp in seconds (e.g., 1682000000) */
+    end?: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,5 @@ export type { PaginatedResult } from './paginatedResult.js';
 export type { TokenResult } from './tokenResult.js';
 export type { OswStackDetail } from './oswStackDetail.js';
 export type { OmadaDeviceStats, OmadaDeviceStatItem, GetDeviceStatsOptions } from './omadaDeviceStats.js';
+export type { ActiveClientInfo } from './activeClientInfo.js';
+export type { ClientActivity, GetClientActivityOptions } from './clientActivity.js';


### PR DESCRIPTION
This pull request adds new functionality to support retrieving dashboard analytics about client activity and top clients by traffic usage from the Omada API. It introduces two new endpoints, exposes them through the client library, and registers new tools for use via the MCP server. Supporting types and documentation are also updated accordingly.

**New dashboard analytics endpoints:**

* Added `listMostActiveClients` to retrieve the most active clients in a site, sorted by total traffic, and exposed it via the `OmadaClient` class and as a new MCP tool. (`src/omadaClient/client.ts` [[1]](diffhunk://#diff-df3a9ff4450e74ad29399f5a50e3d27076449f6df16c13330eb96cfd48ded2b2R31-R70) `src/omadaClient/index.ts` [[2]](diffhunk://#diff-5affee8c41301ca6483ee1bae9eaa03fc1daa6603a54ae50037a076c5decd2f6R106-R113) `src/tools/listMostActiveClients.ts` [[3]](diffhunk://#diff-7c785e9fb7d03247815280465895340305c0581ff8f9e80a2ce42ec59a15bcf3R1-R16) `src/tools/index.ts` [[4]](diffhunk://#diff-a7cc19a6bb39b048b05c5dd7812537802e591624e72321e0ce4778b18d4bf7e1R10-R13) [[5]](diffhunk://#diff-a7cc19a6bb39b048b05c5dd7812537802e591624e72321e0ce4778b18d4bf7e1R26-R27) `README.md` [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152-R153)
* Added `listClientsActivity` to retrieve time-series statistics about new, active, and disconnected clients, and exposed it via the `OmadaClient` class and as a new MCP tool. (`src/omadaClient/client.ts` [[1]](diffhunk://#diff-df3a9ff4450e74ad29399f5a50e3d27076449f6df16c13330eb96cfd48ded2b2R31-R70) `src/omadaClient/index.ts` [[2]](diffhunk://#diff-5affee8c41301ca6483ee1bae9eaa03fc1daa6603a54ae50037a076c5decd2f6R106-R113) `src/tools/listClientsActivity.ts` [[3]](diffhunk://#diff-dea818e2dd7c8c751603fe23046ae38b3d5dc1f5c65dc68c54f508a0496306b4R1-R25) `src/tools/index.ts` [[4]](diffhunk://#diff-a7cc19a6bb39b048b05c5dd7812537802e591624e72321e0ce4778b18d4bf7e1R10-R13) [[5]](diffhunk://#diff-a7cc19a6bb39b048b05c5dd7812537802e591624e72321e0ce4778b18d4bf7e1R26-R27) `README.md` [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152-R153)

**Supporting types and exports:**

* Introduced new types `ActiveClientInfo`, `ClientActivity`, and `GetClientActivityOptions` to model the new dashboard data, and exported them from the type index. (`src/types/activeClientInfo.ts` [[1]](diffhunk://#diff-dc7e6011a51fbc567175eaee56eb11aeba3d44233cdc7aec90df4426ab603d41R1-R17) `src/types/clientActivity.ts` [[2]](diffhunk://#diff-58d5462b53eec9fca9f1edc5970160a6686a50c0df92afd427bf471995103154R1-R32) `src/types/index.ts` [[3]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R9-R10)
* Updated type imports throughout the codebase to include the new types where needed. (`src/omadaClient/client.ts` [[1]](diffhunk://#diff-df3a9ff4450e74ad29399f5a50e3d27076449f6df16c13330eb96cfd48ded2b2L1-R1) `src/omadaClient/index.ts` [[2]](diffhunk://#diff-5affee8c41301ca6483ee1bae9eaa03fc1daa6603a54ae50037a076c5decd2f6L6-R16)…board functionality