### PR TITLE
feat: Add rate limit management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ If an intermediary strips the `Mcp-Session-Id` header, set `MCP_SERVER_STATEFUL=
 | `getSsidList`                   | Gets the list of SSIDs in a WLAN group.                                           |
 | `getSsidDetail`                 | Gets detailed information for a specific SSID.                                    |
 | `getFirewallSetting`            | Gets firewall configuration and rules for a site.                                 |
+| `getRateLimitProfiles`          | Gets the list of available rate limit profiles for bandwidth control.             |
+| `setClientRateLimit`            | Sets custom bandwidth limits (download/upload) for a specific client.             |
+| `setClientRateLimitProfile`     | Applies a predefined rate limit profile to a specific client.                     |
+| `disableClientRateLimit`        | Disables bandwidth rate limiting for a specific client.                           |
 
 ## Supported Omada API Operations
 
@@ -317,6 +321,8 @@ If an intermediary strips the `Mcp-Session-Id` header, set `MCP_SERVER_STATEFUL=
 | `getSsidList`                       | Get SSID list for a WLAN group.                           | Used by `getSsidList`; requires wlanId from `getWlanGroupList`. Use ssidId for `getSsidDetail`.      |
 | `getSsidDetail`                     | Get detailed SSID configuration.                          | Used by `getSsidDetail`; requires wlanId and ssidId. Returns security, rate limits, scheduling.      |
 | `getFirewallSetting`                | Get firewall configuration for a site.                    | Used by `getFirewallSetting`; returns ACL rules, IP groups, security policies.                       |
+| `getRateLimitProfileList`           | Get rate limit profile list.                              | Used by `getRateLimitProfiles`; returns available bandwidth control profiles with limits in Kbps.    |
+| `updateClientRateLimitSetting`      | Set rate limit setting for a client.                      | Used by `setClientRateLimit`, `setClientRateLimitProfile`, and `disableClientRateLimit`.             |
 
 ## Devcontainer support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,9 +257,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+            "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
             "cpu": [
                 "ppc64"
             ],
@@ -274,9 +274,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+            "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
             "cpu": [
                 "arm"
             ],
@@ -291,9 +291,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+            "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
             "cpu": [
                 "arm64"
             ],
@@ -308,9 +308,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+            "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
             "cpu": [
                 "x64"
             ],
@@ -325,9 +325,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+            "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
             "cpu": [
                 "arm64"
             ],
@@ -342,9 +342,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+            "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
             "cpu": [
                 "x64"
             ],
@@ -359,9 +359,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
             "cpu": [
                 "arm64"
             ],
@@ -376,9 +376,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+            "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
             "cpu": [
                 "x64"
             ],
@@ -393,9 +393,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+            "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
             "cpu": [
                 "arm"
             ],
@@ -410,9 +410,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+            "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
             "cpu": [
                 "arm64"
             ],
@@ -427,9 +427,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+            "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
             "cpu": [
                 "ia32"
             ],
@@ -444,9 +444,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+            "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
             "cpu": [
                 "loong64"
             ],
@@ -461,9 +461,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+            "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
             "cpu": [
                 "mips64el"
             ],
@@ -478,9 +478,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+            "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -495,9 +495,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+            "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
             "cpu": [
                 "riscv64"
             ],
@@ -512,9 +512,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+            "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
             "cpu": [
                 "s390x"
             ],
@@ -529,9 +529,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+            "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
             "cpu": [
                 "x64"
             ],
@@ -546,9 +546,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
             "cpu": [
                 "arm64"
             ],
@@ -563,9 +563,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
             "cpu": [
                 "x64"
             ],
@@ -580,9 +580,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+            "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
             "cpu": [
                 "arm64"
             ],
@@ -597,9 +597,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+            "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
             "cpu": [
                 "x64"
             ],
@@ -614,9 +614,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+            "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
             "cpu": [
                 "arm64"
             ],
@@ -631,9 +631,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+            "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
             "cpu": [
                 "x64"
             ],
@@ -648,9 +648,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+            "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
             "cpu": [
                 "arm64"
             ],
@@ -665,9 +665,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+            "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
             "cpu": [
                 "ia32"
             ],
@@ -682,9 +682,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+            "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
             "cpu": [
                 "x64"
             ],
@@ -696,6 +696,18 @@
             ],
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.7",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
+            "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -727,11 +739,12 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.22.0.tgz",
-            "integrity": "sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==",
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
+            "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
             "license": "MIT",
             "dependencies": {
+                "@hono/node-server": "^1.19.7",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
@@ -741,51 +754,57 @@
                 "eventsource-parser": "^3.0.0",
                 "express": "^5.0.1",
                 "express-rate-limit": "^7.5.0",
+                "jose": "^6.1.1",
+                "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
-                "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.24.1"
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.0"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@cfworker/json-schema": "^4.1.1"
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
             },
             "peerDependenciesMeta": {
                 "@cfworker/json-schema": {
                     "optional": true
+                },
+                "zod": {
+                    "optional": false
                 }
             }
         },
         "node_modules/@ngrok/ngrok": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.5.2.tgz",
-            "integrity": "sha512-gN7KKdLTKer+wBSk9s9eDx53MUFdcnXNHsXxiC5sJLLD5HY9JRMSn6UzcCqnk7IgeIgCgw5h1k6YDqhjx6lmtg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.7.0.tgz",
+            "integrity": "sha512-P06o9TpxrJbiRbHQkiwy/rUrlXRupc+Z8KT4MiJfmcdWxvIdzjCaJOdnNkcOTs6DMyzIOefG5tvk/HLdtjqr0g==",
             "license": "(MIT OR Apache-2.0)",
             "engines": {
                 "node": ">= 10"
             },
             "optionalDependencies": {
-                "@ngrok/ngrok-android-arm64": "1.5.2",
-                "@ngrok/ngrok-darwin-arm64": "1.5.2",
-                "@ngrok/ngrok-darwin-universal": "1.5.2",
-                "@ngrok/ngrok-darwin-x64": "1.5.2",
-                "@ngrok/ngrok-freebsd-x64": "1.5.2",
-                "@ngrok/ngrok-linux-arm-gnueabihf": "1.5.2",
-                "@ngrok/ngrok-linux-arm64-gnu": "1.5.2",
-                "@ngrok/ngrok-linux-arm64-musl": "1.5.2",
-                "@ngrok/ngrok-linux-x64-gnu": "1.5.2",
-                "@ngrok/ngrok-linux-x64-musl": "1.5.2",
-                "@ngrok/ngrok-win32-arm64-msvc": "1.5.2",
-                "@ngrok/ngrok-win32-ia32-msvc": "1.5.2",
-                "@ngrok/ngrok-win32-x64-msvc": "1.5.2"
+                "@ngrok/ngrok-android-arm64": "1.7.0",
+                "@ngrok/ngrok-darwin-arm64": "1.7.0",
+                "@ngrok/ngrok-darwin-universal": "1.7.0",
+                "@ngrok/ngrok-darwin-x64": "1.7.0",
+                "@ngrok/ngrok-freebsd-x64": "1.7.0",
+                "@ngrok/ngrok-linux-arm-gnueabihf": "1.7.0",
+                "@ngrok/ngrok-linux-arm64-gnu": "1.7.0",
+                "@ngrok/ngrok-linux-arm64-musl": "1.7.0",
+                "@ngrok/ngrok-linux-x64-gnu": "1.7.0",
+                "@ngrok/ngrok-linux-x64-musl": "1.7.0",
+                "@ngrok/ngrok-win32-arm64-msvc": "1.7.0",
+                "@ngrok/ngrok-win32-ia32-msvc": "1.7.0",
+                "@ngrok/ngrok-win32-x64-msvc": "1.7.0"
             }
         },
         "node_modules/@ngrok/ngrok-android-arm64": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.5.2.tgz",
-            "integrity": "sha512-v81VbxxAgg2W7jbjhEcn8K9R2aUf0h1AuTx+8tDlw3L4H1YEmbmllIpBAGgMjHRBxLZKOo5GBi0k7oS+VRM5TA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.7.0.tgz",
+            "integrity": "sha512-8tco3ID6noSaNy+CMS7ewqPoIkIM6XO5COCzsUp3Wv3XEbMSyn65RN6cflX2JdqLfUCHcMyD0ahr9IEiHwqmbQ==",
             "cpu": [
                 "arm64"
             ],
@@ -799,9 +818,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-darwin-arm64": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.5.2.tgz",
-            "integrity": "sha512-8CVzS9AveYpNhWbydm7cJ6XqmVg29/VRKF15l4kJ2djlNoJxuGSibgM9A627dWRdnJyj5uhmU3VzsgeU8t+/3g==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.7.0.tgz",
+            "integrity": "sha512-+dmJSOzSO+MNDVrPOca2yYDP1W3KfP4qOlAkarIeFRIfqonQwq3QCBmcR7HAlZocLsSqEwyG6KP4RRvAuT0WGQ==",
             "cpu": [
                 "arm64"
             ],
@@ -815,9 +834,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-darwin-universal": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.5.2.tgz",
-            "integrity": "sha512-mEMH1OxN6RxnqRSWb4xY9RqbtdlCpv+WlRKxq4lVy8JVsxEyFNnzVQ0jn+iuiy981jCXjokctzJeGMvECuSQBQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.7.0.tgz",
+            "integrity": "sha512-fDEfewyE2pWGFBhOSwQZObeHUkc65U1l+3HIgSOe094TMHsqmyJD0KTCgW9KSn0VP4OvDZbAISi1T3nvqgZYhQ==",
             "license": "MIT",
             "optional": true,
             "os": [
@@ -828,9 +847,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-darwin-x64": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.5.2.tgz",
-            "integrity": "sha512-rGdcADw4NtMSU7SHUTly7uvMVYX6eMeMCppKyL5g3CSlEQntKf3AWs/89ah2TBWJA2WVl0UgGLkXp4xs1tg9eQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.7.0.tgz",
+            "integrity": "sha512-+fwMi5uHd9G8BS42MMa9ye6exI5lwTcjUO6Ut497Vu0qgLONdVRenRqnEePV+Q3KtQR7NjqkMnomVfkr9MBjtw==",
             "cpu": [
                 "x64"
             ],
@@ -844,9 +863,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-freebsd-x64": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.5.2.tgz",
-            "integrity": "sha512-WgY54qUekaUGa5+lFvzYUMjlzf22IEXuZHhxnzJM2/gMqa7gjU8N5W4U8XNDjVW/oz6DekrzIjuoAEPO+2icDg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.7.0.tgz",
+            "integrity": "sha512-2OGgbrjy3yLRrqAz5N6hlUKIWIXSpR5RjQa2chtZMsSbszQ6c9dI+uVQfOKAeo05tHMUgrYAZ7FocC+ig0dzdQ==",
             "cpu": [
                 "x64"
             ],
@@ -860,9 +879,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-linux-arm-gnueabihf": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.5.2.tgz",
-            "integrity": "sha512-azMxr/TGEeFU4JAUbSu5MO2aZEvdq+TzcxiLw6d+yhdEtNAjDW9TOyCczTrIZPOG5fP8G3lcCd8TP7mVIWdOnw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.7.0.tgz",
+            "integrity": "sha512-SN9YIfEQiR9xN90QVNvdgvAemqMLoFVSeTWZs779145hQMhvF9Qd9rnWi6J+2uNNK10OczdV1oc/nq1es7u/3g==",
             "cpu": [
                 "arm"
             ],
@@ -876,9 +895,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-linux-arm64-gnu": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.5.2.tgz",
-            "integrity": "sha512-79eFCxio4rM0ICRBXx/CVvbXDeWk1Jxr7szkezEYWtHaL+gXivrtS1QjtMnJpGY1GJlLTQL+49w2lGydqPOJQA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.7.0.tgz",
+            "integrity": "sha512-KDMgzPKFU2kbpVSaA2RZBBia5IPdJEe063YlyVFnSMJmPYWCUnMwdybBsucXfV9u1Lw/ZjKTKotIlbTWGn3HGw==",
             "cpu": [
                 "arm64"
             ],
@@ -892,9 +911,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-linux-arm64-musl": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.5.2.tgz",
-            "integrity": "sha512-ou9Z7iPQJIQ0RX5bdBhb3y7GwYRt+X0G9tenyRzKLXXvs0XfUUcg/23aBP61hmdRvBq7xpliV1PnvEVBgUIYMg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.7.0.tgz",
+            "integrity": "sha512-e66vUdVrBlQ0lT9ZdamB4U604zt5Gualt8/WVcUGzbu8s5LajWd6g/mzZCUjK4UepjvMpfgmCp1/+rX7Rk8d5A==",
             "cpu": [
                 "arm64"
             ],
@@ -908,9 +927,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-linux-x64-gnu": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.5.2.tgz",
-            "integrity": "sha512-VI1mmtl3Ie5uXTVAR9thPiMNMsCWeqkjBUbHAyk2vZ2OXR4Vs2DGjOPXK+wTl/hjF29FXoxunjhMy6caF9ht0Q==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.7.0.tgz",
+            "integrity": "sha512-M6gF0DyOEFqXLfWxObfL3bxYZ4+PnKBHuyLVaqNfFN9Y5utY2mdPOn5422Ppbk4XoIK5/YkuhRqPJl/9FivKEw==",
             "cpu": [
                 "x64"
             ],
@@ -924,9 +943,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-linux-x64-musl": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.5.2.tgz",
-            "integrity": "sha512-F4j9EyC/0R3IgYSd+OER4bC8bxuBubvj33e24GvQnRF/IQaKhpybkvQbz54fnvsL7y0j2BB42NAIm2CFtk7tCw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.7.0.tgz",
+            "integrity": "sha512-4Ijm0dKeoyzZTMaYxR2EiNjtlK81ebflg/WYIO1XtleFrVy4UJEGnxtxEidYoT4BfCqi4uvXiK2Mx216xXKvog==",
             "cpu": [
                 "x64"
             ],
@@ -940,9 +959,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-win32-arm64-msvc": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-arm64-msvc/-/ngrok-win32-arm64-msvc-1.5.2.tgz",
-            "integrity": "sha512-0OMXNjWElM1MQX7lMBnpRtafS9+3ybauqGD4m2dZcIm6hFvexsJFwNgx0mCa5aKxe2mQ4zNarEUd+SqG2Aa4/g==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-arm64-msvc/-/ngrok-win32-arm64-msvc-1.7.0.tgz",
+            "integrity": "sha512-u7qyWIJI2/YG1HTBnHwUR1+Z2tyGfAsUAItJK/+N1G0FeWJhIWQvSIFJHlaPy4oW1Dc8mSDBX9qvVsiQgLaRFg==",
             "cpu": [
                 "arm64"
             ],
@@ -956,9 +975,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-win32-ia32-msvc": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.5.2.tgz",
-            "integrity": "sha512-hdvhnr7Br4XhUblpW67v5XP6FyoQwJ2xSbwas4KW4hZ3F4cw0m6sqXpssRfmqg3/5HJony1H5B2jLi0x4J7uOw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.7.0.tgz",
+            "integrity": "sha512-/UdYUsLNv/Q8j9YJsyIfq/jLCoD8WP+NidouucTUzSoDtmOsXBBT3itLrmPiZTEdEgKiFYLuC1Zon8XQQvbVLA==",
             "cpu": [
                 "ia32"
             ],
@@ -972,9 +991,9 @@
             }
         },
         "node_modules/@ngrok/ngrok-win32-x64-msvc": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.5.2.tgz",
-            "integrity": "sha512-aHuMiRti9Taow9DlYLGVmu9CXtXD/v4CBQWpZlmt7VGuK1KsTWWLaGIBFVp6UXnyW87b0A+KC69Kn/Xjylw+sg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.7.0.tgz",
+            "integrity": "sha512-UFJg/duEWzZlLkEs61Gz6/5nYhGaKI62I8dvUGdBR3NCtIMagehnFaFxmnXZldyHmCM8U0aCIFNpWRaKcrQkoA==",
             "cpu": [
                 "x64"
             ],
@@ -1001,9 +1020,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.2.tgz",
-            "integrity": "sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+            "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
             "cpu": [
                 "arm"
             ],
@@ -1015,9 +1034,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.2.tgz",
-            "integrity": "sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+            "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
             "cpu": [
                 "arm64"
             ],
@@ -1029,9 +1048,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.2.tgz",
-            "integrity": "sha512-A6s4gJpomNBtJ2yioj8bflM2oogDwzUiMl2yNJ2v9E7++sHrSrsQ29fOfn5DM/iCzpWcebNYEdXpaK4tr2RhfQ==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+            "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
             "cpu": [
                 "arm64"
             ],
@@ -1043,9 +1062,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.2.tgz",
-            "integrity": "sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+            "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
             "cpu": [
                 "x64"
             ],
@@ -1057,9 +1076,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.2.tgz",
-            "integrity": "sha512-v0E9lJW8VsrwPux5Qe5CwmH/CF/2mQs6xU1MF3nmUxmZUCHazCjLgYvToOk+YuuUqLQBio1qkkREhxhc656ViA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+            "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
             "cpu": [
                 "arm64"
             ],
@@ -1071,9 +1090,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.2.tgz",
-            "integrity": "sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+            "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
             "cpu": [
                 "x64"
             ],
@@ -1085,9 +1104,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.2.tgz",
-            "integrity": "sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+            "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
             "cpu": [
                 "arm"
             ],
@@ -1099,9 +1118,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.2.tgz",
-            "integrity": "sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+            "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
             "cpu": [
                 "arm"
             ],
@@ -1113,9 +1132,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.2.tgz",
-            "integrity": "sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+            "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1127,9 +1146,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.2.tgz",
-            "integrity": "sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+            "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
             "cpu": [
                 "arm64"
             ],
@@ -1141,9 +1160,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.2.tgz",
-            "integrity": "sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+            "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+            "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
             "cpu": [
                 "loong64"
             ],
@@ -1155,9 +1188,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.2.tgz",
-            "integrity": "sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+            "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+            "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1169,9 +1216,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.2.tgz",
-            "integrity": "sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+            "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
             "cpu": [
                 "riscv64"
             ],
@@ -1183,9 +1230,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.2.tgz",
-            "integrity": "sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+            "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
             "cpu": [
                 "riscv64"
             ],
@@ -1197,9 +1244,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.2.tgz",
-            "integrity": "sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+            "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
             "cpu": [
                 "s390x"
             ],
@@ -1211,9 +1258,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.2.tgz",
-            "integrity": "sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+            "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
             "cpu": [
                 "x64"
             ],
@@ -1225,9 +1272,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.2.tgz",
-            "integrity": "sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+            "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
             "cpu": [
                 "x64"
             ],
@@ -1238,10 +1285,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+            "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.2.tgz",
-            "integrity": "sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+            "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
             "cpu": [
                 "arm64"
             ],
@@ -1253,9 +1314,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.2.tgz",
-            "integrity": "sha512-IlbHFYc/pQCgew/d5fslcy1KEaYVCJ44G8pajugd8VoOEI8ODhtb/j8XMhLpwHCMB3yk2J07ctup10gpw2nyMA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+            "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
             "cpu": [
                 "arm64"
             ],
@@ -1267,9 +1328,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.2.tgz",
-            "integrity": "sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+            "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
             "cpu": [
                 "ia32"
             ],
@@ -1281,9 +1342,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.2.tgz",
-            "integrity": "sha512-S6YojNVrHybQis2lYov1sd+uj7K0Q05NxHcGktuMMdIQ2VixGwAfbJ23NnlvvVV1bdpR2m5MsNBViHJKcA4ADw==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+            "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
             "cpu": [
                 "x64"
             ],
@@ -1295,9 +1356,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.2.tgz",
-            "integrity": "sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+            "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
             "cpu": [
                 "x64"
             ],
@@ -1309,9 +1370,9 @@
             ]
         },
         "node_modules/@standard-schema/spec": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
         },
@@ -1341,9 +1402,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.10.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-            "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+            "version": "24.10.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
+            "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -1352,21 +1413,21 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.10.tgz",
-            "integrity": "sha512-g+brmtoKa/sAeIohNJnnWhnHtU6GuqqVOSQ4SxDIPcgZWZyhJs5RmF5LpqXs8Kq64lANP+vnbn5JLzhLj/G56g==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
+            "integrity": "sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.0.10",
+                "@vitest/utils": "4.0.16",
                 "ast-v8-to-istanbul": "^0.3.8",
-                "debug": "^4.4.3",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
                 "istanbul-lib-source-maps": "^5.0.6",
                 "istanbul-reports": "^3.2.0",
                 "magicast": "^0.5.1",
+                "obug": "^2.1.1",
                 "std-env": "^3.10.0",
                 "tinyrainbow": "^3.0.3"
             },
@@ -1374,8 +1435,8 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.0.10",
-                "vitest": "4.0.10"
+                "@vitest/browser": "4.0.16",
+                "vitest": "4.0.16"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -1384,16 +1445,16 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.10.tgz",
-            "integrity": "sha512-3QkTX/lK39FBNwARCQRSQr0TP9+ywSdxSX+LgbJ2M1WmveXP72anTbnp2yl5fH+dU6SUmBzNMrDHs80G8G2DZg==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
+            "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.0.10",
-                "@vitest/utils": "4.0.10",
+                "@vitest/spy": "4.0.16",
+                "@vitest/utils": "4.0.16",
                 "chai": "^6.2.1",
                 "tinyrainbow": "^3.0.3"
             },
@@ -1402,13 +1463,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.10.tgz",
-            "integrity": "sha512-e2OfdexYkjkg8Hh3L9NVEfbwGXq5IZbDovkf30qW2tOh7Rh9sVtmSr2ztEXOFbymNxS4qjzLXUQIvATvN4B+lg==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
+            "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.0.10",
+                "@vitest/spy": "4.0.16",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1429,9 +1490,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.10.tgz",
-            "integrity": "sha512-99EQbpa/zuDnvVjthwz5bH9o8iPefoQZ63WV8+bsRJZNw3qQSvSltfut8yu1Jc9mqOYi7pEbsKxYTi/rjaq6PA==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
+            "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1442,13 +1503,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.10.tgz",
-            "integrity": "sha512-EXU2iSkKvNwtlL8L8doCpkyclw0mc/t4t9SeOnfOFPyqLmQwuceMPA4zJBa6jw0MKsZYbw7kAn+gl7HxrlB8UQ==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
+            "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.0.10",
+                "@vitest/utils": "4.0.16",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1456,13 +1517,13 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.10.tgz",
-            "integrity": "sha512-2N4X2ZZl7kZw0qeGdQ41H0KND96L3qX1RgwuCfy6oUsF2ISGD/HpSbmms+CkIOsQmg2kulwfhJ4CI0asnZlvkg==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
+            "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.0.10",
+                "@vitest/pretty-format": "4.0.16",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1471,9 +1532,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.10.tgz",
-            "integrity": "sha512-AsY6sVS8OLb96GV5RoG8B6I35GAbNrC49AO+jNRF9YVGb/g9t+hzNm1H6kD0NDp8tt7VJLs6hb7YMkDXqu03iw==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
+            "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1481,14 +1542,14 @@
             }
         },
         "node_modules/@vitest/ui": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.10.tgz",
-            "integrity": "sha512-oWtNM89Np+YsQO3ttT5i1Aer/0xbzQzp66NzuJn/U16bB7MnvSzdLKXgk1kkMLYyKSSzA2ajzqMkYheaE9opuQ==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.16.tgz",
+            "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vitest/utils": "4.0.10",
+                "@vitest/utils": "4.0.16",
                 "fflate": "^0.8.2",
                 "flatted": "^3.3.3",
                 "pathe": "^2.0.3",
@@ -1500,17 +1561,17 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "4.0.10"
+                "vitest": "4.0.16"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.10.tgz",
-            "integrity": "sha512-kOuqWnEwZNtQxMKg3WmPK1vmhZu9WcoX69iwWjVz+jvKTsF1emzsv3eoPcDr6ykA3qP2bsCQE7CwqfNtAVzsmg==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
+            "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.0.10",
+                "@vitest/pretty-format": "4.0.16",
                 "tinyrainbow": "^3.0.3"
             },
             "funding": {
@@ -1600,9 +1661,9 @@
             }
         },
         "node_modules/ast-v8-to-istanbul": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
-            "integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+            "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1638,23 +1699,27 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/bytes": {
@@ -1696,9 +1761,9 @@
             }
         },
         "node_modules/chai": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
-            "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1808,15 +1873,16 @@
             }
         },
         "node_modules/content-disposition": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
             "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/content-type": {
@@ -2009,9 +2075,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.25.12",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+            "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2022,32 +2088,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.12",
-                "@esbuild/android-arm": "0.25.12",
-                "@esbuild/android-arm64": "0.25.12",
-                "@esbuild/android-x64": "0.25.12",
-                "@esbuild/darwin-arm64": "0.25.12",
-                "@esbuild/darwin-x64": "0.25.12",
-                "@esbuild/freebsd-arm64": "0.25.12",
-                "@esbuild/freebsd-x64": "0.25.12",
-                "@esbuild/linux-arm": "0.25.12",
-                "@esbuild/linux-arm64": "0.25.12",
-                "@esbuild/linux-ia32": "0.25.12",
-                "@esbuild/linux-loong64": "0.25.12",
-                "@esbuild/linux-mips64el": "0.25.12",
-                "@esbuild/linux-ppc64": "0.25.12",
-                "@esbuild/linux-riscv64": "0.25.12",
-                "@esbuild/linux-s390x": "0.25.12",
-                "@esbuild/linux-x64": "0.25.12",
-                "@esbuild/netbsd-arm64": "0.25.12",
-                "@esbuild/netbsd-x64": "0.25.12",
-                "@esbuild/openbsd-arm64": "0.25.12",
-                "@esbuild/openbsd-x64": "0.25.12",
-                "@esbuild/openharmony-arm64": "0.25.12",
-                "@esbuild/sunos-x64": "0.25.12",
-                "@esbuild/win32-arm64": "0.25.12",
-                "@esbuild/win32-ia32": "0.25.12",
-                "@esbuild/win32-x64": "0.25.12"
+                "@esbuild/aix-ppc64": "0.27.2",
+                "@esbuild/android-arm": "0.27.2",
+                "@esbuild/android-arm64": "0.27.2",
+                "@esbuild/android-x64": "0.27.2",
+                "@esbuild/darwin-arm64": "0.27.2",
+                "@esbuild/darwin-x64": "0.27.2",
+                "@esbuild/freebsd-arm64": "0.27.2",
+                "@esbuild/freebsd-x64": "0.27.2",
+                "@esbuild/linux-arm": "0.27.2",
+                "@esbuild/linux-arm64": "0.27.2",
+                "@esbuild/linux-ia32": "0.27.2",
+                "@esbuild/linux-loong64": "0.27.2",
+                "@esbuild/linux-mips64el": "0.27.2",
+                "@esbuild/linux-ppc64": "0.27.2",
+                "@esbuild/linux-riscv64": "0.27.2",
+                "@esbuild/linux-s390x": "0.27.2",
+                "@esbuild/linux-x64": "0.27.2",
+                "@esbuild/netbsd-arm64": "0.27.2",
+                "@esbuild/netbsd-x64": "0.27.2",
+                "@esbuild/openbsd-arm64": "0.27.2",
+                "@esbuild/openbsd-x64": "0.27.2",
+                "@esbuild/openharmony-arm64": "0.27.2",
+                "@esbuild/sunos-x64": "0.27.2",
+                "@esbuild/win32-arm64": "0.27.2",
+                "@esbuild/win32-ia32": "0.27.2",
+                "@esbuild/win32-x64": "0.27.2"
             }
         },
         "node_modules/escalade": {
@@ -2107,9 +2173,9 @@
             }
         },
         "node_modules/expect-type": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-            "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2117,19 +2183,20 @@
             }
         },
         "node_modules/express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
+                "body-parser": "^2.2.1",
                 "content-disposition": "^1.0.0",
                 "content-type": "^1.0.5",
                 "cookie": "^0.7.1",
                 "cookie-signature": "^1.2.1",
                 "debug": "^4.4.0",
+                "depd": "^2.0.0",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
@@ -2222,9 +2289,9 @@
             "license": "MIT"
         },
         "node_modules/finalhandler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
@@ -2235,7 +2302,11 @@
                 "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/flatted": {
@@ -2465,6 +2536,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hono": {
+            "version": "4.11.3",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
+            "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2473,40 +2554,39 @@
             "license": "MIT"
         },
         "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/http-errors/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+            "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/inherits": {
@@ -2613,6 +2693,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/jose": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+            "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2625,6 +2714,12 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -2704,15 +2799,19 @@
             }
         },
         "node_modules/mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "license": "MIT",
             "dependencies": {
                 "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/mrmime": {
@@ -2779,6 +2878,17 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
         "node_modules/on-exit-leak-free": {
             "version": "2.1.2",
@@ -2904,9 +3014,9 @@
             "license": "MIT"
         },
         "node_modules/pkce-challenge": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-            "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.20.0"
@@ -2977,9 +3087,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.14.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -3007,34 +3117,18 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-            "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.7.0",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/raw-body/node_modules/iconv-lite": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/real-require": {
@@ -3076,9 +3170,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.53.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
-            "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+            "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3092,28 +3186,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.53.2",
-                "@rollup/rollup-android-arm64": "4.53.2",
-                "@rollup/rollup-darwin-arm64": "4.53.2",
-                "@rollup/rollup-darwin-x64": "4.53.2",
-                "@rollup/rollup-freebsd-arm64": "4.53.2",
-                "@rollup/rollup-freebsd-x64": "4.53.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.53.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.53.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.53.2",
-                "@rollup/rollup-linux-arm64-musl": "4.53.2",
-                "@rollup/rollup-linux-loong64-gnu": "4.53.2",
-                "@rollup/rollup-linux-ppc64-gnu": "4.53.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.53.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.53.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.53.2",
-                "@rollup/rollup-linux-x64-gnu": "4.53.2",
-                "@rollup/rollup-linux-x64-musl": "4.53.2",
-                "@rollup/rollup-openharmony-arm64": "4.53.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.53.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.53.2",
-                "@rollup/rollup-win32-x64-gnu": "4.53.2",
-                "@rollup/rollup-win32-x64-msvc": "4.53.2",
+                "@rollup/rollup-android-arm-eabi": "4.55.1",
+                "@rollup/rollup-android-arm64": "4.55.1",
+                "@rollup/rollup-darwin-arm64": "4.55.1",
+                "@rollup/rollup-darwin-x64": "4.55.1",
+                "@rollup/rollup-freebsd-arm64": "4.55.1",
+                "@rollup/rollup-freebsd-x64": "4.55.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+                "@rollup/rollup-linux-arm64-musl": "4.55.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+                "@rollup/rollup-linux-loong64-musl": "4.55.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+                "@rollup/rollup-linux-x64-gnu": "4.55.1",
+                "@rollup/rollup-linux-x64-musl": "4.55.1",
+                "@rollup/rollup-openbsd-x64": "4.55.1",
+                "@rollup/rollup-openharmony-arm64": "4.55.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+                "@rollup/rollup-win32-x64-gnu": "4.55.1",
+                "@rollup/rollup-win32-x64-msvc": "4.55.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -3142,26 +3239,6 @@
             "dependencies": {
                 "tslib": "^2.1.0"
             }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/safe-stable-stringify": {
             "version": "2.5.0",
@@ -3192,31 +3269,35 @@
             }
         },
         "node_modules/send": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
             "license": "MIT",
             "dependencies": {
-                "debug": "^4.3.5",
+                "debug": "^4.4.3",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
                 "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "mime-types": "^3.0.1",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
                 "ms": "^2.1.3",
                 "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
-                "statuses": "^2.0.1"
+                "statuses": "^2.0.2"
             },
             "engines": {
                 "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
             "license": "MIT",
             "dependencies": {
                 "encodeurl": "^2.0.0",
@@ -3226,6 +3307,10 @@
             },
             "engines": {
                 "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/setprototypeof": {
@@ -3474,11 +3559,14 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+            "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
@@ -3544,14 +3632,14 @@
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.20.6",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
-            "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "esbuild": "~0.25.0",
+                "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
             },
             "bin": {
@@ -3618,14 +3706,14 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
-            "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "esbuild": "^0.25.0",
+                "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
@@ -3694,29 +3782,29 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.10.tgz",
-            "integrity": "sha512-2Fqty3MM9CDwOVet/jaQalYlbcjATZwPYGcqpiYQqgQ/dLC7GuHdISKgTYIVF/kaishKxLzleKWWfbSDklyIKg==",
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
+            "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@vitest/expect": "4.0.10",
-                "@vitest/mocker": "4.0.10",
-                "@vitest/pretty-format": "4.0.10",
-                "@vitest/runner": "4.0.10",
-                "@vitest/snapshot": "4.0.10",
-                "@vitest/spy": "4.0.10",
-                "@vitest/utils": "4.0.10",
-                "debug": "^4.4.3",
+                "@vitest/expect": "4.0.16",
+                "@vitest/mocker": "4.0.16",
+                "@vitest/pretty-format": "4.0.16",
+                "@vitest/runner": "4.0.16",
+                "@vitest/snapshot": "4.0.16",
+                "@vitest/spy": "4.0.16",
+                "@vitest/utils": "4.0.16",
                 "es-module-lexer": "^1.7.0",
                 "expect-type": "^1.2.2",
                 "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
                 "pathe": "^2.0.3",
                 "picomatch": "^4.0.3",
                 "std-env": "^3.10.0",
                 "tinybench": "^2.9.0",
-                "tinyexec": "^0.3.2",
+                "tinyexec": "^1.0.2",
                 "tinyglobby": "^0.2.15",
                 "tinyrainbow": "^3.0.3",
                 "vite": "^6.0.0 || ^7.0.0",
@@ -3733,12 +3821,12 @@
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@types/debug": "^4.1.12",
+                "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.0.10",
-                "@vitest/browser-preview": "4.0.10",
-                "@vitest/browser-webdriverio": "4.0.10",
-                "@vitest/ui": "4.0.10",
+                "@vitest/browser-playwright": "4.0.16",
+                "@vitest/browser-preview": "4.0.16",
+                "@vitest/browser-webdriverio": "4.0.16",
+                "@vitest/ui": "4.0.16",
                 "happy-dom": "*",
                 "jsdom": "*"
             },
@@ -3746,7 +3834,7 @@
                 "@edge-runtime/vm": {
                     "optional": true
                 },
-                "@types/debug": {
+                "@opentelemetry/api": {
                     "optional": true
                 },
                 "@types/node": {
@@ -3878,12 +3966,12 @@
             }
         },
         "node_modules/zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+            "version": "3.25.1",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+            "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
             "license": "ISC",
             "peerDependencies": {
-                "zod": "^3.24.1"
+                "zod": "^3.25 || ^4"
             }
         }
     }

--- a/src/omadaClient/client.ts
+++ b/src/omadaClient/client.ts
@@ -2,11 +2,14 @@ import type {
     ActiveClientInfo,
     ClientActivity,
     ClientPastConnection,
+    ClientRateLimitSetting,
     GetClientActivityOptions,
     ListClientsPastConnectionsOptions,
     OmadaApiResponse,
     OmadaClientInfo,
     PaginatedResult,
+    RateLimitProfile,
+    UpdateClientRateLimitRequest,
 } from '../types/index.js';
 
 import type { RequestHandler } from './request.js';
@@ -120,5 +123,103 @@ export class ClientOperations {
 
         const result = this.request.ensureSuccess(response);
         return result.data ?? [];
+    }
+
+    /**
+     * Get rate limit profile list for a site.
+     * Returns available rate limit profiles that can be applied to clients.
+     *
+     * @param siteId - Optional site ID, uses default from config if not provided
+     * @returns Array of rate limit profiles
+     */
+    public async getRateLimitProfiles(siteId?: string): Promise<RateLimitProfile[]> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const response = await this.request.get<OmadaApiResponse<RateLimitProfile[]>>(
+            this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/rate-limit-profiles`)
+        );
+        return response.result ?? [];
+    }
+
+    /**
+     * Set custom rate limit for a client.
+     * Configures download and upload bandwidth limits directly without using a profile.
+     *
+     * @param clientMac - MAC address of the client
+     * @param downLimit - Download limit in Kbps
+     * @param upLimit - Upload limit in Kbps
+     * @param siteId - Optional site ID, uses default from config if not provided
+     * @returns Updated rate limit setting
+     */
+    public async setClientRateLimit(clientMac: string, downLimit: number, upLimit: number, siteId?: string): Promise<ClientRateLimitSetting> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const requestBody: UpdateClientRateLimitRequest = {
+            mode: 0, // 0 = custom rate limit
+            customRateLimit: {
+                enable: true,
+                upEnable: true,
+                upLimit: upLimit,
+                downEnable: true,
+                downLimit: downLimit,
+            },
+        };
+
+        const response = await this.request.patch<OmadaApiResponse<ClientRateLimitSetting>>(
+            this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/clients/${encodeURIComponent(clientMac)}/ratelimit`),
+            requestBody
+        );
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Set rate limit profile for a client.
+     * Applies a predefined rate limit profile to the client.
+     *
+     * @param clientMac - MAC address of the client
+     * @param profileId - Rate limit profile ID
+     * @param siteId - Optional site ID, uses default from config if not provided
+     * @returns Updated rate limit setting
+     */
+    public async setClientRateLimitProfile(clientMac: string, profileId: string, siteId?: string): Promise<ClientRateLimitSetting> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const requestBody: UpdateClientRateLimitRequest = {
+            mode: 1, // 1 = use rate limit profile
+            rateLimitProfileId: profileId,
+        };
+
+        const response = await this.request.patch<OmadaApiResponse<ClientRateLimitSetting>>(
+            this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/clients/${encodeURIComponent(clientMac)}/ratelimit`),
+            requestBody
+        );
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Disable rate limit for a client.
+     * Removes any rate limiting applied to the client.
+     *
+     * @param clientMac - MAC address of the client
+     * @param siteId - Optional site ID, uses default from config if not provided
+     * @returns Updated rate limit setting
+     */
+    public async disableClientRateLimit(clientMac: string, siteId?: string): Promise<ClientRateLimitSetting> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+
+        // To disable rate limiting, use mode 0 with enable: false and minimal valid limit values
+        const requestBody: UpdateClientRateLimitRequest = {
+            mode: 0,
+            customRateLimit: {
+                enable: false,
+                upEnable: false,
+                upLimit: 1,
+                downEnable: false,
+                downLimit: 1,
+            },
+        };
+
+        const response = await this.request.patch<OmadaApiResponse<ClientRateLimitSetting>>(
+            this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/clients/${encodeURIComponent(clientMac)}/ratelimit`),
+            requestBody
+        );
+        return this.request.ensureSuccess(response);
     }
 }

--- a/src/omadaClient/index.ts
+++ b/src/omadaClient/index.ts
@@ -7,6 +7,7 @@ import type {
     ActiveClientInfo,
     ClientActivity,
     ClientPastConnection,
+    ClientRateLimitSetting,
     GetClientActivityOptions,
     GetDeviceStatsOptions,
     GetThreatListOptions,
@@ -17,6 +18,7 @@ import type {
     OmadaSiteSummary,
     OswStackDetail,
     PaginatedResult,
+    RateLimitProfile,
     ThreatInfo,
 } from '../types/index.js';
 
@@ -126,6 +128,23 @@ export class OmadaClient {
 
     public async listClientsPastConnections(options: ListClientsPastConnectionsOptions): Promise<ClientPastConnection[]> {
         return await this.clientOps.listClientsPastConnections(options);
+    }
+
+    // Rate limit operations
+    public async getRateLimitProfiles(siteId?: string): Promise<RateLimitProfile[]> {
+        return await this.clientOps.getRateLimitProfiles(siteId);
+    }
+
+    public async setClientRateLimit(clientMac: string, downLimit: number, upLimit: number, siteId?: string): Promise<ClientRateLimitSetting> {
+        return await this.clientOps.setClientRateLimit(clientMac, downLimit, upLimit, siteId);
+    }
+
+    public async setClientRateLimitProfile(clientMac: string, profileId: string, siteId?: string): Promise<ClientRateLimitSetting> {
+        return await this.clientOps.setClientRateLimitProfile(clientMac, profileId, siteId);
+    }
+
+    public async disableClientRateLimit(clientMac: string, siteId?: string): Promise<ClientRateLimitSetting> {
+        return await this.clientOps.disableClientRateLimit(clientMac, siteId);
     }
 
     // Security operations

--- a/src/omadaClient/request.ts
+++ b/src/omadaClient/request.ts
@@ -24,6 +24,13 @@ export class RequestHandler {
     }
 
     /**
+     * Make a PATCH request to the Omada API.
+     */
+    public async patch<T>(path: string, data?: unknown): Promise<T> {
+        return await this.request<T>({ method: 'PATCH', url: path, data });
+    }
+
+    /**
      * Make an arbitrary HTTP request to the Omada API.
      */
     public async request<T>(config: AxiosRequestConfig, retry = true): Promise<T> {

--- a/src/tools/disableClientRateLimit.ts
+++ b/src/tools/disableClientRateLimit.ts
@@ -1,0 +1,22 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerDisableClientRateLimitTool(server: McpServer, client: OmadaClient): void {
+    const inputSchema = z.object({
+        clientMac: z.string().min(1, 'clientMac (MAC address) is required'),
+        siteId: z.string().min(1).optional(),
+    });
+
+    server.registerTool(
+        'disableClientRateLimit',
+        {
+            description: 'Disable rate limiting for a specific client, removing any bandwidth restrictions.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('disableClientRateLimit', async ({ clientMac, siteId }) =>
+            toToolResult(await client.disableClientRateLimit(clientMac, siteId))
+        )
+    );
+}

--- a/src/tools/getRateLimitProfiles.ts
+++ b/src/tools/getRateLimitProfiles.ts
@@ -1,0 +1,16 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerGetRateLimitProfilesTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getRateLimitProfiles',
+        {
+            description:
+                'Get the list of available rate limit profiles for a site. These profiles can be applied to clients to control their bandwidth usage.',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('getRateLimitProfiles', async ({ siteId }) => toToolResult(await client.getRateLimitProfiles(siteId)))
+    );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { OmadaClient } from '../omadaClient/index.js';
 
+import { registerDisableClientRateLimitTool } from './disableClientRateLimit.js';
 import { registerGetClientTool } from './getClient.js';
 import { registerGetDeviceTool } from './getDevice.js';
 import { registerGetFirewallSettingTool } from './getFirewallSetting.js';
@@ -9,6 +10,7 @@ import { registerGetInternetInfoTool } from './getInternetInfo.js';
 import { registerGetLanNetworkListTool } from './getLanNetworkList.js';
 import { registerGetLanProfileListTool } from './getLanProfileList.js';
 import { registerGetPortForwardingStatusTool } from './getPortForwardingStatus.js';
+import { registerGetRateLimitProfilesTool } from './getRateLimitProfiles.js';
 import { registerGetSsidDetailTool } from './getSsidDetail.js';
 import { registerGetSsidListTool } from './getSsidList.js';
 import { registerGetSwitchStackDetailTool } from './getSwitchStackDetail.js';
@@ -22,6 +24,8 @@ import { registerListDevicesStatsTool } from './listDevicesStats.js';
 import { registerListMostActiveClientsTool } from './listMostActiveClients.js';
 import { registerListSitesTool } from './listSites.js';
 import { registerSearchDevicesTool } from './searchDevices.js';
+import { registerSetClientRateLimitTool } from './setClientRateLimit.js';
+import { registerSetClientRateLimitProfileTool } from './setClientRateLimitProfile.js';
 
 export function registerAllTools(server: McpServer, client: OmadaClient): void {
     registerListSitesTool(server, client);
@@ -44,4 +48,8 @@ export function registerAllTools(server: McpServer, client: OmadaClient): void {
     registerGetSsidListTool(server, client);
     registerGetSsidDetailTool(server, client);
     registerGetFirewallSettingTool(server, client);
+    registerGetRateLimitProfilesTool(server, client);
+    registerSetClientRateLimitTool(server, client);
+    registerSetClientRateLimitProfileTool(server, client);
+    registerDisableClientRateLimitTool(server, client);
 }

--- a/src/tools/setClientRateLimit.ts
+++ b/src/tools/setClientRateLimit.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerSetClientRateLimitTool(server: McpServer, client: OmadaClient): void {
+    const inputSchema = z.object({
+        clientMac: z.string().min(1, 'clientMac (MAC address) is required'),
+        downLimit: z.number().positive('downLimit must be a positive number (in Kbps)'),
+        upLimit: z.number().positive('upLimit must be a positive number (in Kbps)'),
+        siteId: z.string().min(1).optional(),
+    });
+
+    server.registerTool(
+        'setClientRateLimit',
+        {
+            description:
+                'Set custom rate limit (bandwidth control) for a specific client. Specify download and upload limits in Kbps. This configures custom limits directly without using a predefined profile.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('setClientRateLimit', async ({ clientMac, downLimit, upLimit, siteId }) =>
+            toToolResult(await client.setClientRateLimit(clientMac, downLimit, upLimit, siteId))
+        )
+    );
+}

--- a/src/tools/setClientRateLimitProfile.ts
+++ b/src/tools/setClientRateLimitProfile.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerSetClientRateLimitProfileTool(server: McpServer, client: OmadaClient): void {
+    const inputSchema = z.object({
+        clientMac: z.string().min(1, 'clientMac (MAC address) is required'),
+        profileId: z.string().min(1, 'profileId (rate limit profile ID) is required'),
+        siteId: z.string().min(1).optional(),
+    });
+
+    server.registerTool(
+        'setClientRateLimitProfile',
+        {
+            description: 'Apply a predefined rate limit profile to a specific client. Use getRateLimitProfiles to get available profile IDs.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('setClientRateLimitProfile', async ({ clientMac, profileId, siteId }) =>
+            toToolResult(await client.setClientRateLimitProfile(clientMac, profileId, siteId))
+        )
+    );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,5 +8,6 @@ export type { GetDeviceStatsOptions, OmadaDeviceStatItem, OmadaDeviceStats } fro
 export type { OmadaSiteSummary } from './omadaSiteSummary.js';
 export type { OswStackDetail } from './oswStackDetail.js';
 export type { PaginatedResult } from './paginatedResult.js';
+export type { ClientRateLimitSetting, RateLimitProfile, UpdateClientRateLimitRequest } from './rateLimitProfile.js';
 export type { GetThreatListOptions, ThreatInfo } from './threatInfo.js';
 export type { TokenResult } from './tokenResult.js';

--- a/src/types/rateLimitProfile.ts
+++ b/src/types/rateLimitProfile.ts
@@ -1,0 +1,58 @@
+/**
+ * Rate limit profile information from Omada API
+ */
+export interface RateLimitProfile {
+    /** Profile ID */
+    id: string;
+    /** Profile name (1-64 characters) */
+    name: string;
+    /** Whether download limit is enabled */
+    downLimitEnable: boolean;
+    /** Download limit in Kbps (when downLimitEnable is true) */
+    downLimit?: number;
+    /** Whether upload limit is enabled */
+    upLimitEnable: boolean;
+    /** Upload limit in Kbps (when upLimitEnable is true) */
+    upLimit?: number;
+}
+
+/**
+ * Client rate limit setting
+ */
+export interface ClientRateLimitSetting {
+    /** Rate limit profile ID (null when using custom rate limit) */
+    rateLimitId?: string | null;
+    /** Whether rate limit is enabled */
+    enable: boolean;
+    /** Whether upload limit is enabled (for custom rate limit) */
+    upEnable?: boolean;
+    /** Upload limit in Kbps (for custom rate limit) */
+    upLimit?: number;
+    /** Whether download limit is enabled (for custom rate limit) */
+    downEnable?: boolean;
+    /** Download limit in Kbps (for custom rate limit) */
+    downLimit?: number;
+}
+
+/**
+ * Request to update client rate limit setting
+ */
+export interface UpdateClientRateLimitRequest {
+    /** Mode: 0 = custom rate limit, 1 = use rate limit profile */
+    mode: 0 | 1;
+    /** Rate limit profile ID (required when mode = 1) */
+    rateLimitProfileId?: string;
+    /** Custom rate limit settings (required when mode = 0) */
+    customRateLimit?: {
+        /** Whether rate limit is enabled */
+        enable: boolean;
+        /** Whether upload limit is enabled */
+        upEnable?: boolean;
+        /** Upload limit in Kbps */
+        upLimit?: number;
+        /** Whether download limit is enabled */
+        downEnable?: boolean;
+        /** Download limit in Kbps */
+        downLimit?: number;
+    };
+}

--- a/tests/omadaClient/client.test.ts
+++ b/tests/omadaClient/client.test.ts
@@ -2,7 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ClientOperations } from '../../src/omadaClient/client.js';
 import type { RequestHandler } from '../../src/omadaClient/request.js';
 import type { SiteOperations } from '../../src/omadaClient/site.js';
-import type { ActiveClientInfo, ClientActivity, ClientPastConnection, OmadaApiResponse, OmadaClientInfo } from '../../src/types/index.js';
+import type {
+    ActiveClientInfo,
+    ClientActivity,
+    ClientPastConnection,
+    ClientRateLimitSetting,
+    OmadaApiResponse,
+    OmadaClientInfo,
+    RateLimitProfile,
+} from '../../src/types/index.js';
 
 describe('omadaClient/client', () => {
     let mockRequest: RequestHandler;
@@ -14,6 +22,7 @@ describe('omadaClient/client', () => {
         mockRequest = {
             fetchPaginated: vi.fn(),
             get: vi.fn(),
+            patch: vi.fn(),
             ensureSuccess: vi.fn((response) => response.result),
         } as unknown as RequestHandler;
 
@@ -321,6 +330,224 @@ describe('omadaClient/client', () => {
             });
 
             expect(connections).toEqual([]);
+        });
+    });
+
+    describe('getRateLimitProfiles', () => {
+        it('should fetch rate limit profiles', async () => {
+            const mockProfiles: RateLimitProfile[] = [
+                {
+                    id: 'profile-1',
+                    name: 'Low Speed',
+                    downLimitEnable: true,
+                    downLimit: 1024,
+                    upLimitEnable: true,
+                    upLimit: 512,
+                },
+                {
+                    id: 'profile-2',
+                    name: 'High Speed',
+                    downLimitEnable: true,
+                    downLimit: 10240,
+                    upLimitEnable: true,
+                    upLimit: 5120,
+                },
+            ];
+
+            const mockResponse: OmadaApiResponse<RateLimitProfile[]> = {
+                errorCode: 0,
+                msg: 'Success',
+                result: mockProfiles,
+            };
+
+            (mockRequest.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+            const profiles = await clientOps.getRateLimitProfiles('test-site');
+
+            expect(profiles).toEqual(mockProfiles);
+            expect(mockSite.resolveSiteId).toHaveBeenCalledWith('test-site');
+            expect(mockRequest.get).toHaveBeenCalledWith('/api/sites/test-site/rate-limit-profiles');
+        });
+
+        it('should return empty array if result is undefined', async () => {
+            const mockResponse: OmadaApiResponse<RateLimitProfile[]> = {
+                errorCode: 0,
+                msg: 'Success',
+            };
+
+            (mockRequest.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+            const profiles = await clientOps.getRateLimitProfiles();
+
+            expect(profiles).toEqual([]);
+        });
+    });
+
+    describe('setClientRateLimit', () => {
+        it('should set custom rate limit for a client', async () => {
+            const mockSetting: ClientRateLimitSetting = {
+                enable: true,
+                upEnable: true,
+                upLimit: 5120,
+                downEnable: true,
+                downLimit: 10240,
+            };
+
+            const mockResponse: OmadaApiResponse<ClientRateLimitSetting> = {
+                errorCode: 0,
+                msg: 'Success',
+                result: mockSetting,
+            };
+
+            (mockRequest.patch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+            (mockRequest.ensureSuccess as ReturnType<typeof vi.fn>).mockReturnValue(mockSetting);
+
+            const setting = await clientOps.setClientRateLimit('00:11:22:33:44:55', 10240, 5120, 'test-site');
+
+            expect(setting).toEqual(mockSetting);
+            expect(mockSite.resolveSiteId).toHaveBeenCalledWith('test-site');
+            expect(mockRequest.patch).toHaveBeenCalledWith('/api/sites/test-site/clients/00%3A11%3A22%3A33%3A44%3A55/ratelimit', {
+                mode: 0,
+                customRateLimit: {
+                    enable: true,
+                    upEnable: true,
+                    upLimit: 5120,
+                    downEnable: true,
+                    downLimit: 10240,
+                },
+            });
+            expect(mockRequest.ensureSuccess).toHaveBeenCalledWith(mockResponse);
+        });
+
+        it('should use default siteId if not provided', async () => {
+            const mockSetting: ClientRateLimitSetting = {
+                enable: true,
+                upEnable: true,
+                upLimit: 1024,
+                downEnable: true,
+                downLimit: 2048,
+            };
+
+            const mockResponse: OmadaApiResponse<ClientRateLimitSetting> = {
+                errorCode: 0,
+                msg: 'Success',
+                result: mockSetting,
+            };
+
+            (mockRequest.patch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+            (mockRequest.ensureSuccess as ReturnType<typeof vi.fn>).mockReturnValue(mockSetting);
+
+            await clientOps.setClientRateLimit('00:11:22:33:44:55', 2048, 1024);
+
+            expect(mockSite.resolveSiteId).toHaveBeenCalledWith(undefined);
+            expect(mockRequest.patch).toHaveBeenCalledWith(
+                '/api/sites/default-site/clients/00%3A11%3A22%3A33%3A44%3A55/ratelimit',
+                expect.any(Object)
+            );
+        });
+    });
+
+    describe('setClientRateLimitProfile', () => {
+        it('should apply a rate limit profile to a client', async () => {
+            const mockSetting: ClientRateLimitSetting = {
+                rateLimitId: 'profile-1',
+                enable: true,
+            };
+
+            const mockResponse: OmadaApiResponse<ClientRateLimitSetting> = {
+                errorCode: 0,
+                msg: 'Success',
+                result: mockSetting,
+            };
+
+            (mockRequest.patch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+            (mockRequest.ensureSuccess as ReturnType<typeof vi.fn>).mockReturnValue(mockSetting);
+
+            const setting = await clientOps.setClientRateLimitProfile('00:11:22:33:44:55', 'profile-1', 'test-site');
+
+            expect(setting).toEqual(mockSetting);
+            expect(mockSite.resolveSiteId).toHaveBeenCalledWith('test-site');
+            expect(mockRequest.patch).toHaveBeenCalledWith('/api/sites/test-site/clients/00%3A11%3A22%3A33%3A44%3A55/ratelimit', {
+                mode: 1,
+                rateLimitProfileId: 'profile-1',
+            });
+            expect(mockRequest.ensureSuccess).toHaveBeenCalledWith(mockResponse);
+        });
+
+        it('should use default siteId if not provided', async () => {
+            const mockSetting: ClientRateLimitSetting = {
+                rateLimitId: 'profile-2',
+                enable: true,
+            };
+
+            const mockResponse: OmadaApiResponse<ClientRateLimitSetting> = {
+                errorCode: 0,
+                msg: 'Success',
+                result: mockSetting,
+            };
+
+            (mockRequest.patch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+            (mockRequest.ensureSuccess as ReturnType<typeof vi.fn>).mockReturnValue(mockSetting);
+
+            await clientOps.setClientRateLimitProfile('00:11:22:33:44:55', 'profile-2');
+
+            expect(mockSite.resolveSiteId).toHaveBeenCalledWith(undefined);
+            expect(mockRequest.patch).toHaveBeenCalledWith(
+                '/api/sites/default-site/clients/00%3A11%3A22%3A33%3A44%3A55/ratelimit',
+                expect.any(Object)
+            );
+        });
+    });
+
+    describe('disableClientRateLimit', () => {
+        it('should disable rate limit for a client', async () => {
+            const mockSetting: ClientRateLimitSetting = {
+                enable: false,
+            };
+
+            const mockResponse: OmadaApiResponse<ClientRateLimitSetting> = {
+                errorCode: 0,
+                msg: 'Success',
+                result: mockSetting,
+            };
+
+            (mockRequest.patch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+            (mockRequest.ensureSuccess as ReturnType<typeof vi.fn>).mockReturnValue(mockSetting);
+
+            const setting = await clientOps.disableClientRateLimit('00:11:22:33:44:55', 'test-site');
+
+            expect(setting).toEqual(mockSetting);
+            expect(mockSite.resolveSiteId).toHaveBeenCalledWith('test-site');
+            expect(mockRequest.patch).toHaveBeenCalledWith('/api/sites/test-site/clients/00%3A11%3A22%3A33%3A44%3A55/ratelimit', {
+                mode: 0,
+                customRateLimit: {
+                    enable: false,
+                    upEnable: false,
+                    upLimit: 1,
+                    downEnable: false,
+                    downLimit: 1,
+                },
+            });
+            expect(mockRequest.ensureSuccess).toHaveBeenCalledWith(mockResponse);
+        });
+
+        it('should use default siteId if not provided', async () => {
+            const mockSetting: ClientRateLimitSetting = {
+                enable: false,
+            };
+
+            const mockResponse: OmadaApiResponse<ClientRateLimitSetting> = {
+                errorCode: 0,
+                msg: 'Success',
+                result: mockSetting,
+            };
+
+            (mockRequest.patch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+            (mockRequest.ensureSuccess as ReturnType<typeof vi.fn>).mockReturnValue(mockSetting);
+
+            await clientOps.disableClientRateLimit('00:11:22:33:44:55');
+
+            expect(mockSite.resolveSiteId).toHaveBeenCalledWith(undefined);
         });
     });
 });

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -40,9 +40,13 @@ describe('tools/index', () => {
             expect(mockServer.registerTool).toHaveBeenCalledWith('getSsidList', expect.any(Object), expect.any(Function));
             expect(mockServer.registerTool).toHaveBeenCalledWith('getSsidDetail', expect.any(Object), expect.any(Function));
             expect(mockServer.registerTool).toHaveBeenCalledWith('getFirewallSetting', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getRateLimitProfiles', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('setClientRateLimit', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('setClientRateLimitProfile', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('disableClientRateLimit', expect.any(Object), expect.any(Function));
 
             // Verify total number of tools registered
-            expect(mockServer.registerTool).toHaveBeenCalledTimes(20);
+            expect(mockServer.registerTool).toHaveBeenCalledTimes(24);
         });
     });
 });


### PR DESCRIPTION
## Summary
This PR adds comprehensive rate limit management functionality to the TP-Link Omada MCP server, allowing users to control bandwidth limits for individual clients programmatically.

## Changes

### New Features
- **Four new rate limit management tools:**
  - `disableClientRateLimit`: Remove rate limits from clients
  - `getRateLimitProfiles`: List available rate limit profiles configured in Omada
  - `setClientRateLimit`: Apply custom bandwidth limits (upload/download in Kbps)
  - `setClientRateLimitProfile`: Apply predefined rate limit profiles to clients

### Improvements
- Updated client and request handling to support rate limit operations
- Enhanced type definitions with new `rateLimitProfile` types
- Added comprehensive test coverage for new functionality

## Testing
- All existing tests pass
- New tests added for rate limit functionality
- Tested with actual Omada controller (verified working)

## Breaking Changes
None - all changes are additive.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (README if applicable)
- [x] All tests pass
- [x] Commits follow conventional commit format
