### PR TITLE
feat(tools): implement dashboard & monitor tools

### DIFF
--- a/src/omadaClient/index.ts
+++ b/src/omadaClient/index.ts
@@ -371,8 +371,12 @@ export class OmadaClient {
         return await this.monitorOps.getDashboardSwitchSummary(siteId, customHeaders);
     }
 
-    public async getDashboardTrafficDistribution(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
-        return await this.monitorOps.getDashboardTrafficDistribution(siteId, customHeaders);
+    public async getTrafficDistribution(siteId?: string, start?: number, end?: number, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getTrafficDistribution(siteId, start, end, customHeaders);
+    }
+
+    public async getRetryAndDroppedRate(siteId?: string, start?: number, end?: number, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getRetryAndDroppedRate(siteId, start, end, customHeaders);
     }
 
     public async getDashboardTrafficActivities(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
@@ -403,12 +407,28 @@ export class OmadaClient {
         return await this.monitorOps.getDashboardOverview(siteId, customHeaders);
     }
 
-    public async getDashboardChannels(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
-        return await this.monitorOps.getDashboardChannels(siteId, customHeaders);
+    public async getChannels(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getChannels(siteId, customHeaders);
     }
 
-    public async getDashboardIspLoad(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
-        return await this.monitorOps.getDashboardIspLoad(siteId, customHeaders);
+    public async getIspLoad(siteId?: string, start?: number, end?: number, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getIspLoad(siteId, start, end, customHeaders);
+    }
+
+    public async getInterference(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getInterference(siteId, customHeaders);
+    }
+
+    public async getGridDashboardTunnelStats(siteId?: string, type?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getGridDashboardTunnelStats(siteId, type, customHeaders);
+    }
+
+    public async getGridDashboardIpsecTunnelStats(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getGridDashboardIpsecTunnelStats(siteId, customHeaders);
+    }
+
+    public async getGridDashboardOpenVpnTunnelStats(siteId?: string, type?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        return await this.monitorOps.getGridDashboardOpenVpnTunnelStats(siteId, type, customHeaders);
     }
 
     // Insight operations

--- a/src/omadaClient/monitor.ts
+++ b/src/omadaClient/monitor.ts
@@ -40,10 +40,21 @@ export class MonitorOperations {
      * Get traffic distribution statistics for a site dashboard.
      * OperationId: getTrafficDistribution
      */
-    public async getDashboardTrafficDistribution(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+    public async getTrafficDistribution(siteId?: string, start?: number, end?: number, customHeaders?: CustomHeaders): Promise<unknown> {
         const resolvedSiteId = this.site.resolveSiteId(siteId);
         const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/traffic-distribution`);
-        const response = await this.request.get<OmadaApiResponse<unknown>>(path, undefined, customHeaders);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path, { start, end }, customHeaders);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get wireless retry rate and dropped packet rate over a time range.
+     * OperationId: getRetryAndDroppedRate
+     */
+    public async getRetryAndDroppedRate(siteId?: string, start?: number, end?: number, customHeaders?: CustomHeaders): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/retry-dropped-rate`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path, { start, end }, customHeaders);
         return this.request.ensureSuccess(response);
     }
 
@@ -125,10 +136,10 @@ export class MonitorOperations {
     }
 
     /**
-     * Get channel usage statistics for a site dashboard.
+     * Get channel distribution and utilization across all APs.
      * OperationId: getChannels
      */
-    public async getDashboardChannels(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+    public async getChannels(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
         const resolvedSiteId = this.site.resolveSiteId(siteId);
         const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/channels`);
         const response = await this.request.get<OmadaApiResponse<unknown>>(path, undefined, customHeaders);
@@ -136,13 +147,57 @@ export class MonitorOperations {
     }
 
     /**
-     * Get ISP load balance statistics for a site dashboard.
+     * Get per-WAN ISP link load over a time range.
      * OperationId: getIspLoad
      */
-    public async getDashboardIspLoad(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+    public async getIspLoad(siteId?: string, start?: number, end?: number, customHeaders?: CustomHeaders): Promise<unknown> {
         const resolvedSiteId = this.site.resolveSiteId(siteId);
         const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/isp-load`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path, { start, end }, customHeaders);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get top RF interference sources detected by APs.
+     * OperationId: getInterference
+     */
+    public async getInterference(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/top-interference`);
         const response = await this.request.get<OmadaApiResponse<unknown>>(path, undefined, customHeaders);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get VPN tunnel statistics by type.
+     * OperationId: getGridDashboardTunnelStats
+     */
+    public async getGridDashboardTunnelStats(siteId?: string, type?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/vpn-tunnel-stats`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path, { type }, customHeaders);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get IPsec tunnel statistics.
+     * OperationId: getGridDashboardIpsecTunnelStats
+     */
+    public async getGridDashboardIpsecTunnelStats(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/lpset-tunnel-stats`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path, undefined, customHeaders);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get OpenVPN tunnel statistics by type.
+     * OperationId: getGridDashboardOpenVpnTunnelStats
+     */
+    public async getGridDashboardOpenVpnTunnelStats(siteId?: string, type?: string, customHeaders?: CustomHeaders): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/dashboard/open-vpn-tunnel-stats`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path, { type }, customHeaders);
         return this.request.ensureSuccess(response);
     }
 }

--- a/src/tools/getChannels.ts
+++ b/src/tools/getChannels.ts
@@ -1,0 +1,16 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerGetChannelsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getChannels',
+        {
+            description:
+                'Get channel distribution and utilization across all APs. Shows which WiFi channels (2.4 GHz, 5 GHz, 6 GHz) are in use, how many APs are on each channel, and channel congestion. Useful for diagnosing interference and planning channel assignments.',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('getChannels', async ({ siteId, customHeaders }) => toToolResult(await client.getChannels(siteId, customHeaders)))
+    );
+}

--- a/src/tools/getGridDashboardIpsecTunnelStats.ts
+++ b/src/tools/getGridDashboardIpsecTunnelStats.ts
@@ -1,0 +1,18 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerGetGridDashboardIpsecTunnelStatsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getGridDashboardIpsecTunnelStats',
+        {
+            description:
+                'Get IPsec tunnel statistics for the site dashboard. Returns connection counts, traffic volumes, and tunnel health for all IPsec VPN tunnels.',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('getGridDashboardIpsecTunnelStats', async ({ siteId, customHeaders }) =>
+            toToolResult(await client.getGridDashboardIpsecTunnelStats(siteId, customHeaders))
+        )
+    );
+}

--- a/src/tools/getGridDashboardOpenVpnTunnelStats.ts
+++ b/src/tools/getGridDashboardOpenVpnTunnelStats.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+const inputSchema = siteInputSchema.extend({
+    type: z
+        .string()
+        .min(1)
+        .describe('OpenVPN tunnel type filter. Determines which OpenVPN tunnel statistics are returned. Check your controller for supported values.'),
+});
+
+export function registerGetGridDashboardOpenVpnTunnelStatsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getGridDashboardOpenVpnTunnelStats',
+        {
+            description:
+                'Get OpenVPN tunnel statistics by type for the site dashboard. Returns connection counts, traffic volumes, and status for OpenVPN tunnels.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('getGridDashboardOpenVpnTunnelStats', async ({ siteId, type, customHeaders }) =>
+            toToolResult(await client.getGridDashboardOpenVpnTunnelStats(siteId, type, customHeaders))
+        )
+    );
+}

--- a/src/tools/getGridDashboardTunnelStats.ts
+++ b/src/tools/getGridDashboardTunnelStats.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+const inputSchema = siteInputSchema.extend({
+    type: z
+        .string()
+        .min(1)
+        .describe(
+            'VPN type filter. Determines which tunnel type statistics are returned (e.g. "ipsec", "openvpn", "wireguard", "l2tp"). Check your controller for supported values.'
+        ),
+});
+
+export function registerGetGridDashboardTunnelStatsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getGridDashboardTunnelStats',
+        {
+            description:
+                'Get VPN tunnel statistics by type. Returns connection counts, traffic volumes, and status for VPN tunnels of the specified type (IPsec, OpenVPN, WireGuard, etc.). Use getVpnTunnelStats for a broader summary.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('getGridDashboardTunnelStats', async ({ siteId, type, customHeaders }) =>
+            toToolResult(await client.getGridDashboardTunnelStats(siteId, type, customHeaders))
+        )
+    );
+}

--- a/src/tools/getInterference.ts
+++ b/src/tools/getInterference.ts
@@ -1,0 +1,16 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerGetInterferenceTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getInterference',
+        {
+            description:
+                'Get top RF interference sources detected by APs. Identifies nearby networks or devices causing wireless interference on each channel. Useful for diagnosing poor WiFi performance caused by external RF environment.',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('getInterference', async ({ siteId, customHeaders }) => toToolResult(await client.getInterference(siteId, customHeaders)))
+    );
+}

--- a/src/tools/getIspLoad.ts
+++ b/src/tools/getIspLoad.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+const inputSchema = siteInputSchema.extend({
+    start: z
+        .number()
+        .int()
+        .positive()
+        .describe(
+            'Start of the time range as a Unix timestamp in milliseconds (e.g. Date.now() - 3600000 for the last hour). Must be paired with end.'
+        ),
+    end: z
+        .number()
+        .int()
+        .positive()
+        .describe('End of the time range as a Unix timestamp in milliseconds (e.g. Date.now()). Must be paired with start.'),
+});
+
+export function registerGetIspLoadTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getIspLoad',
+        {
+            description:
+                'Get per-WAN ISP link load over a time range. Shows traffic volume and utilization per internet uplink. Useful for understanding load balancing behaviour, identifying saturated WAN links, and analysing failover events.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('getIspLoad', async ({ siteId, start, end, customHeaders }) =>
+            toToolResult(await client.getIspLoad(siteId, start, end, customHeaders))
+        )
+    );
+}

--- a/src/tools/getRetryAndDroppedRate.ts
+++ b/src/tools/getRetryAndDroppedRate.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+const inputSchema = siteInputSchema.extend({
+    start: z
+        .number()
+        .int()
+        .positive()
+        .describe(
+            'Start of the time range as a Unix timestamp in milliseconds (e.g. Date.now() - 3600000 for the last hour). Must be paired with end.'
+        ),
+    end: z
+        .number()
+        .int()
+        .positive()
+        .describe('End of the time range as a Unix timestamp in milliseconds (e.g. Date.now()). Must be paired with start.'),
+});
+
+export function registerGetRetryAndDroppedRateTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getRetryAndDroppedRate',
+        {
+            description:
+                'Get wireless retry rate and dropped packet rate over a time range. High retry rates indicate RF interference or weak signal; high drop rates indicate capacity or hardware issues. Useful for diagnosing WiFi quality problems.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('getRetryAndDroppedRate', async ({ siteId, start, end, customHeaders }) =>
+            toToolResult(await client.getRetryAndDroppedRate(siteId, start, end, customHeaders))
+        )
+    );
+}

--- a/src/tools/getTrafficDistribution.ts
+++ b/src/tools/getTrafficDistribution.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+const inputSchema = siteInputSchema.extend({
+    start: z
+        .number()
+        .int()
+        .positive()
+        .describe(
+            'Start of the time range as a Unix timestamp in milliseconds (e.g. Date.now() - 3600000 for the last hour). Must be paired with end.'
+        ),
+    end: z
+        .number()
+        .int()
+        .positive()
+        .describe('End of the time range as a Unix timestamp in milliseconds (e.g. Date.now()). Must be paired with start.'),
+});
+
+export function registerGetTrafficDistributionTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getTrafficDistribution',
+        {
+            description:
+                'Get traffic distribution by protocol and application type over a time range. Shows breakdown of traffic by category (video, gaming, web, etc.) helping identify what is consuming bandwidth on the network.',
+            inputSchema: inputSchema.shape,
+        },
+        wrapToolHandler('getTrafficDistribution', async ({ siteId, start, end, customHeaders }) =>
+            toToolResult(await client.getTrafficDistribution(siteId, start, end, customHeaders))
+        )
+    );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerDisableClientRateLimitTool } from './disableClientRateLimit.js'
 import { registerGetApDetailTool } from './getApDetail.js';
 import { registerGetApplicationControlStatusTool } from './getApplicationControlStatus.js';
 import { registerGetApRadiosTool } from './getApRadios.js';
+import { registerGetChannelsTool } from './getChannels.js';
 import { registerGetClientTool } from './getClient.js';
 import { registerGetDashboardMostActiveEapsTool } from './getDashboardMostActiveEaps.js';
 import { registerGetDashboardMostActiveSwitchesTool } from './getDashboardMostActiveSwitches.js';
@@ -21,11 +22,17 @@ import { registerGetGatewayDetailTool } from './getGatewayDetail.js';
 import { registerGetGatewayLanStatusTool } from './getGatewayLanStatus.js';
 import { registerGetGatewayPortsTool } from './getGatewayPorts.js';
 import { registerGetGatewayWanStatusTool } from './getGatewayWanStatus.js';
+import { registerGetGridDashboardIpsecTunnelStatsTool } from './getGridDashboardIpsecTunnelStats.js';
+import { registerGetGridDashboardOpenVpnTunnelStatsTool } from './getGridDashboardOpenVpnTunnelStats.js';
+import { registerGetGridDashboardTunnelStatsTool } from './getGridDashboardTunnelStats.js';
+import { registerGetInterferenceTool } from './getInterference.js';
 import { registerGetInternetInfoTool } from './getInternetInfo.js';
+import { registerGetIspLoadTool } from './getIspLoad.js';
 import { registerGetLanNetworkListTool } from './getLanNetworkList.js';
 import { registerGetLanProfileListTool } from './getLanProfileList.js';
 import { registerGetPortForwardingStatusTool } from './getPortForwardingStatus.js';
 import { registerGetRateLimitProfilesTool } from './getRateLimitProfiles.js';
+import { registerGetRetryAndDroppedRateTool } from './getRetryAndDroppedRate.js';
 import { registerGetRogueApsTool } from './getRogueAps.js';
 import { registerGetSshSettingTool } from './getSshSetting.js';
 import { registerGetSsidDetailTool } from './getSsidDetail.js';
@@ -35,6 +42,7 @@ import { registerGetSwitchDetailTool } from './getSwitchDetail.js';
 import { registerGetSwitchStackDetailTool } from './getSwitchStackDetail.js';
 import { registerGetThreatListTool } from './getThreatList.js';
 import { registerGetTopThreatsTool } from './getTopThreats.js';
+import { registerGetTrafficDistributionTool } from './getTrafficDistribution.js';
 import { registerGetVpnSettingsTool } from './getVpnSettings.js';
 import { registerGetVpnTunnelStatsTool } from './getVpnTunnelStats.js';
 import { registerGetWanLanStatusTool } from './getWanLanStatus.js';
@@ -138,6 +146,14 @@ export function registerAllTools(server: McpServer, client: OmadaClient): void {
     registerGetDashboardMostActiveSwitchesTool(server, client);
     registerGetDashboardMostActiveEapsTool(server, client);
     registerGetDashboardOverviewTool(server, client);
+    registerGetTrafficDistributionTool(server, client);
+    registerGetRetryAndDroppedRateTool(server, client);
+    registerGetIspLoadTool(server, client);
+    registerGetChannelsTool(server, client);
+    registerGetInterferenceTool(server, client);
+    registerGetGridDashboardTunnelStatsTool(server, client);
+    registerGetGridDashboardIpsecTunnelStatsTool(server, client);
+    registerGetGridDashboardOpenVpnTunnelStatsTool(server, client);
 
     // Insight operations
     registerGetWidsTool(server, client);

--- a/tests/omadaClient/monitor.test.ts
+++ b/tests/omadaClient/monitor.test.ts
@@ -70,12 +70,12 @@ describe('MonitorOperations', () => {
         });
     });
 
-    describe('getDashboardTrafficDistribution', () => {
+    describe('getTrafficDistribution', () => {
         it('should fetch traffic distribution', async () => {
             const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: { categories: [] } };
             vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
 
-            const result = await monitorOps.getDashboardTrafficDistribution('site-123');
+            const result = await monitorOps.getTrafficDistribution('site-123', 1000000, 2000000);
 
             expect(result).toEqual({ categories: [] });
         });
@@ -170,25 +170,80 @@ describe('MonitorOperations', () => {
         });
     });
 
-    describe('getDashboardChannels', () => {
+    describe('getChannels', () => {
         it('should fetch channel information', async () => {
             const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: { channels: [] } };
             vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
 
-            const result = await monitorOps.getDashboardChannels('site-123');
+            const result = await monitorOps.getChannels('site-123');
 
             expect(result).toEqual({ channels: [] });
         });
     });
 
-    describe('getDashboardIspLoad', () => {
+    describe('getIspLoad', () => {
         it('should fetch ISP load information', async () => {
             const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: { load: 0.5 } };
             vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
 
-            const result = await monitorOps.getDashboardIspLoad('site-123');
+            const result = await monitorOps.getIspLoad('site-123', 1000000, 2000000);
 
             expect(result).toEqual({ load: 0.5 });
+        });
+    });
+
+    describe('getRetryAndDroppedRate', () => {
+        it('should fetch retry and dropped rate', async () => {
+            const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: { retryRate: 0.1, dropRate: 0.02 } };
+            vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
+
+            const result = await monitorOps.getRetryAndDroppedRate('site-123', 1000000, 2000000);
+
+            expect(result).toEqual({ retryRate: 0.1, dropRate: 0.02 });
+        });
+    });
+
+    describe('getInterference', () => {
+        it('should fetch interference data', async () => {
+            const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: [] };
+            vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
+
+            const result = await monitorOps.getInterference('site-123');
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('getGridDashboardTunnelStats', () => {
+        it('should fetch tunnel stats by type', async () => {
+            const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: { total: 2 } };
+            vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
+
+            const result = await monitorOps.getGridDashboardTunnelStats('site-123', 'ipsec');
+
+            expect(result).toEqual({ total: 2 });
+        });
+    });
+
+    describe('getGridDashboardIpsecTunnelStats', () => {
+        it('should fetch IPsec tunnel stats', async () => {
+            const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: { connected: 1 } };
+            vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
+
+            const result = await monitorOps.getGridDashboardIpsecTunnelStats('site-123');
+
+            expect(result).toEqual({ connected: 1 });
+        });
+    });
+
+    describe('getGridDashboardOpenVpnTunnelStats', () => {
+        it('should fetch OpenVPN tunnel stats by type', async () => {
+            const mockResponse: OmadaApiResponse<unknown> = { errorCode: 0, result: { connected: 3 } };
+            vi.mocked(mockRequest.get).mockResolvedValue(mockResponse);
+
+            const result = await monitorOps.getGridDashboardOpenVpnTunnelStats('site-123', 'server');
+
+            expect(result).toEqual({ connected: 3 });
         });
     });
 });

--- a/tests/tools/dashboardMonitorTools.test.ts
+++ b/tests/tools/dashboardMonitorTools.test.ts
@@ -1,0 +1,129 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OmadaClient } from '../../src/omadaClient/index.js';
+import { registerGetChannelsTool } from '../../src/tools/getChannels.js';
+import { registerGetGridDashboardIpsecTunnelStatsTool } from '../../src/tools/getGridDashboardIpsecTunnelStats.js';
+import { registerGetGridDashboardOpenVpnTunnelStatsTool } from '../../src/tools/getGridDashboardOpenVpnTunnelStats.js';
+import { registerGetGridDashboardTunnelStatsTool } from '../../src/tools/getGridDashboardTunnelStats.js';
+import { registerGetInterferenceTool } from '../../src/tools/getInterference.js';
+import { registerGetIspLoadTool } from '../../src/tools/getIspLoad.js';
+import { registerGetRetryAndDroppedRateTool } from '../../src/tools/getRetryAndDroppedRate.js';
+import { registerGetTrafficDistributionTool } from '../../src/tools/getTrafficDistribution.js';
+import * as loggerModule from '../../src/utils/logger.js';
+
+describe('tools - dashboard & monitor tools (issue #34)', () => {
+    let mockServer: McpServer;
+    let mockClient: OmadaClient;
+    let toolHandler: (args: unknown, extra: { sessionId?: string }) => Promise<unknown>;
+
+    const captureHandler = (_name: string, _schema: unknown, handler: typeof toolHandler): void => {
+        toolHandler = handler;
+    };
+
+    beforeEach(() => {
+        mockServer = {
+            registerTool: vi.fn(captureHandler),
+        } as unknown as McpServer;
+
+        mockClient = {
+            getTrafficDistribution: vi.fn().mockResolvedValue({ data: [] }),
+            getRetryAndDroppedRate: vi.fn().mockResolvedValue({ data: [] }),
+            getIspLoad: vi.fn().mockResolvedValue({ data: [] }),
+            getChannels: vi.fn().mockResolvedValue({ data: [] }),
+            getInterference: vi.fn().mockResolvedValue([]),
+            getGridDashboardTunnelStats: vi.fn().mockResolvedValue({ data: [] }),
+            getGridDashboardIpsecTunnelStats: vi.fn().mockResolvedValue({ data: [] }),
+            getGridDashboardOpenVpnTunnelStats: vi.fn().mockResolvedValue({ data: [] }),
+        } as unknown as OmadaClient;
+
+        vi.spyOn(loggerModule.logger, 'info').mockImplementation(() => {
+            // noop
+        });
+        vi.spyOn(loggerModule.logger, 'error').mockImplementation(() => {
+            // noop
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('getTrafficDistribution', () => {
+        it('should call client with start and end params', async () => {
+            registerGetTrafficDistributionTool(mockServer, mockClient);
+            const result = await toolHandler({ start: 1000000, end: 2000000 }, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getTrafficDistribution).toHaveBeenCalledWith(undefined, 1000000, 2000000, undefined);
+        });
+
+        it('should pass siteId when provided', async () => {
+            registerGetTrafficDistributionTool(mockServer, mockClient);
+            await toolHandler({ siteId: 'site-1', start: 1000000, end: 2000000 }, {});
+            expect(mockClient.getTrafficDistribution).toHaveBeenCalledWith('site-1', 1000000, 2000000, undefined);
+        });
+    });
+
+    describe('getRetryAndDroppedRate', () => {
+        it('should call client with start and end params', async () => {
+            registerGetRetryAndDroppedRateTool(mockServer, mockClient);
+            const result = await toolHandler({ start: 1000000, end: 2000000 }, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getRetryAndDroppedRate).toHaveBeenCalledWith(undefined, 1000000, 2000000, undefined);
+        });
+    });
+
+    describe('getIspLoad', () => {
+        it('should call client with start and end params', async () => {
+            registerGetIspLoadTool(mockServer, mockClient);
+            const result = await toolHandler({ start: 1000000, end: 2000000 }, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getIspLoad).toHaveBeenCalledWith(undefined, 1000000, 2000000, undefined);
+        });
+    });
+
+    describe('getChannels', () => {
+        it('should execute successfully', async () => {
+            registerGetChannelsTool(mockServer, mockClient);
+            const result = await toolHandler({}, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getChannels).toHaveBeenCalledWith(undefined, undefined);
+        });
+    });
+
+    describe('getInterference', () => {
+        it('should execute successfully', async () => {
+            registerGetInterferenceTool(mockServer, mockClient);
+            const result = await toolHandler({}, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getInterference).toHaveBeenCalledWith(undefined, undefined);
+        });
+    });
+
+    describe('getGridDashboardTunnelStats', () => {
+        it('should call client with type param', async () => {
+            registerGetGridDashboardTunnelStatsTool(mockServer, mockClient);
+            const result = await toolHandler({ type: 'ipsec' }, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getGridDashboardTunnelStats).toHaveBeenCalledWith(undefined, 'ipsec', undefined);
+        });
+    });
+
+    describe('getGridDashboardIpsecTunnelStats', () => {
+        it('should execute successfully', async () => {
+            registerGetGridDashboardIpsecTunnelStatsTool(mockServer, mockClient);
+            const result = await toolHandler({}, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getGridDashboardIpsecTunnelStats).toHaveBeenCalledWith(undefined, undefined);
+        });
+    });
+
+    describe('getGridDashboardOpenVpnTunnelStats', () => {
+        it('should call client with type param', async () => {
+            registerGetGridDashboardOpenVpnTunnelStatsTool(mockServer, mockClient);
+            const result = await toolHandler({ type: 'server' }, {});
+            expect(result).toBeDefined();
+            expect(mockClient.getGridDashboardOpenVpnTunnelStats).toHaveBeenCalledWith(undefined, 'server', undefined);
+        });
+    });
+});

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -85,6 +85,14 @@ describe('tools/index', () => {
             expect(mockServer.registerTool).toHaveBeenCalledWith('getDashboardMostActiveSwitches', expect.any(Object), expect.any(Function));
             expect(mockServer.registerTool).toHaveBeenCalledWith('getDashboardMostActiveEaps', expect.any(Object), expect.any(Function));
             expect(mockServer.registerTool).toHaveBeenCalledWith('getDashboardOverview', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getTrafficDistribution', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getRetryAndDroppedRate', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getIspLoad', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getChannels', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getInterference', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getGridDashboardTunnelStats', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getGridDashboardIpsecTunnelStats', expect.any(Object), expect.any(Function));
+            expect(mockServer.registerTool).toHaveBeenCalledWith('getGridDashboardOpenVpnTunnelStats', expect.any(Object), expect.any(Function));
 
             // Insight tools
             expect(mockServer.registerTool).toHaveBeenCalledWith('getWids', expect.any(Object), expect.any(Function));
@@ -99,7 +107,7 @@ describe('tools/index', () => {
             expect(mockServer.registerTool).toHaveBeenCalledWith('listGlobalAlerts', expect.any(Object), expect.any(Function));
 
             // Verify total number of tools registered
-            expect(mockServer.registerTool).toHaveBeenCalledTimes(65);
+            expect(mockServer.registerTool).toHaveBeenCalledTimes(73);
         });
     });
 });


### PR DESCRIPTION
## Summary

Implements all 8 missing Dashboard & Monitor tools from issue #34.

## New Tools

| Tool | Endpoint | Description |
|---|---|---|
| `getTrafficDistribution` | `GET /dashboard/traffic-distribution` | Traffic by protocol/app type over time range |
| `getRetryAndDroppedRate` | `GET /dashboard/retry-dropped-rate` | Wireless retry & drop rates over time range |
| `getIspLoad` | `GET /dashboard/isp-load` | Per-WAN ISP link load over time range |
| `getChannels` | `GET /dashboard/channels` | Channel distribution across all APs |
| `getInterference` | `GET /dashboard/top-interference` | Top RF interference sources |
| `getGridDashboardTunnelStats` | `GET /dashboard/vpn-tunnel-stats` | VPN tunnel stats by type |
| `getGridDashboardIpsecTunnelStats` | `GET /dashboard/lpset-tunnel-stats` | IPsec tunnel stats |
| `getGridDashboardOpenVpnTunnelStats` | `GET /dashboard/open-vpn-tunnel-stats` | OpenVPN tunnel stats by type |

## Test Coverage
- **487 tests passing** (up from 473)
- **Coverage: 91.1%** (above 90% threshold)
- New test file: `tests/tools/dashboardMonitorTools.test.ts`

## Checklist
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` passes (487/487)
- [x] Coverage ≥ 90%
- [x] All tools documented with accurate descriptions and parameter docs

Closes #34