### PR TITLE
docs(CLAUDE.md): mandate API validation before tool implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,21 @@ git commit -m "chore: restore AI instruction symlinks"
 - **IMPORTANT** All source files must use LF (Unix-style) line endings, not CRLF (Windows-style). Biome will automatically convert line endings when running `npm run format`.
 - If you encounter formatting errors related to line endings (shown as `␍` in error messages), run `npm run format` to fix them automatically.
 
+## API Validation Before Implementation (MANDATORY)
+
+Before implementing any new tool, the following rules apply:
+
+1. **Verify the endpoint exists** — check `docs/openapi/` to confirm the API route is documented before writing any code.
+2. **Use `OMADA_TOOLS.md` as ground truth** — every tool in that file has a verified route. If a tool is listed there with a route, you can implement it.
+3. **If not in `OMADA_TOOLS.md` and not in `docs/openapi/`** — do NOT implement it. Instead, raise a GitHub issue or add a comment to the existing issue noting the missing endpoint, and skip the tool.
+4. **Never infer or guess API routes** — only implement against verified spec paths.
+5. **When fixing route mismatches** — always check `docs/openapi/` for the correct path. Do not assume the current code is correct.
+
 ## Contribution Guidelines
 
 - Keep environment secrets out of the repo; only commit `.env.example`.
 - **Before every commit**, all of the following must pass:
+  0. **API route verification** — every new tool's route must exist in `docs/openapi/` or `OMADA_TOOLS.md`. Run: `grep -c "your-route" docs/openapi/*.json` to confirm.
   1. `npm run check` — Biome lint + TypeScript type check
   2. `npm run build` — TypeScript compilation
   3. `npm test` — full test suite


### PR DESCRIPTION
## Summary

- Adds a new **"API Validation Before Implementation (MANDATORY)"** section to `CLAUDE.md` requiring all new tools to have verified API routes before any code is written.
- Adds a **step 0** to the pre-commit checklist requiring route verification against `docs/openapi/` or `OMADA_TOOLS.md` before lint/build/test.

## Background

This rule was added to prevent a repeat of the PR #79 incident, where 72 tools were implemented with unverified API routes. Those tools had to be removed after code review because the routes were inferred or guessed rather than confirmed against the OpenAPI spec. The new rule mandates that every tool's route must exist in `docs/openapi/` or `OMADA_TOOLS.md` before implementation begins — and explicitly prohibits implementing tools whose endpoints cannot be confirmed.

## Test plan

- [ ] Verify `CLAUDE.md` contains the new "API Validation Before Implementation (MANDATORY)" section
- [ ] Verify step 0 appears in the pre-commit checklist before step 1
- [ ] Confirm symlinks (`AGENTS.md`, `.github/copilot-instructions.md`, `.github/AGENTS.md`) still point to `CLAUDE.md` and reflect the new content
- [ ] CI symlink integrity check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)