### PR TITLE
docs: README fixes — stale category markers, missing param docs (Part 2 of #84)

### DIFF
--- a/README.Docker.md
+++ b/README.Docker.md
@@ -288,7 +288,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getWanHealthDetail` | Deprecated alias. Gets WAN health details for a specific gateway. Requires `gatewayMac`. |
 | `getWanUsageStats` | [DEPRECATED] Use `getDashboardTrafficActivities` instead. Gets WAN traffic usage statistics for the site. |
 | `getWanNatConfig` | Gets one-to-one NAT rules (paginated). |
-| `getPortForwardingStatus` | Gets port forwarding status and rules (User or UPnP types). |
+| `getPortForwardingStatus` | Gets port forwarding status and rules. Required: `type` (`user` or `upnp`), `page`, `pageSize`. |
 | `getLanNetworkList` | [DEPRECATED] Use `getLanNetworkListV2` instead. This tool aggregates all pages; getLanNetworkListV2 is explicitly paginated. |
 | `getLanNetworkListV2` | Get the LAN network list using the v2 API, with richer VLAN and DHCP data (paginated). |
 | `getInterfaceLanNetwork` | Gets interface-level LAN network bindings. Optional type filter. |
@@ -299,7 +299,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getMulticastRateLimit` | Get multicast rate limit settings for a site. |
 | `getWlanGroupList` | Gets the list of WLAN groups configured in a site. |
 | `getSsidList` | Gets the list of SSIDs in a WLAN group. |
-| `getSsidDetail` | Gets detailed information for a specific SSID. |
+| `getSsidDetail` | Gets detailed information for a specific SSID. Required: `wlanId` and `ssidId`. |
 | `listAllSsids` | Lists wireless SSIDs across all WLAN groups. |
 | `getFirewallSetting` | Gets firewall configuration and rules for a site. |
 | `getVpnSettings` | Gets VPN settings for a site. |
@@ -402,7 +402,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getIspLoad` | Gets per-WAN ISP link load over a time range. Requires `start` and `end` timestamps (seconds). |
 | `getChannels` | Gets channel distribution and utilization across all APs. |
 | `getInterference` | Gets top RF interference sources detected by APs. |
-| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics by type. Requires `type` parameter. |
+| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics. Required: `type` (`ipsec`, `openvpn`, or `wireguard`). |
 | `getGridDashboardIpsecTunnelStats` | Gets IPsec tunnel statistics.                                 |
 | `getGridDashboardOpenVpnTunnelStats` | Gets OpenVPN tunnel statistics by type. Requires `type` parameter. |
 

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -288,7 +288,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getWanHealthDetail` | Deprecated alias. Gets WAN health details for a specific gateway. Requires `gatewayMac`. |
 | `getWanUsageStats` | [DEPRECATED] Use `getDashboardTrafficActivities` instead. Gets WAN traffic usage statistics for the site. |
 | `getWanNatConfig` | Gets one-to-one NAT rules (paginated). |
-| `getPortForwardingStatus` | Gets port forwarding status and rules. Required: `type` (`user` or `upnp`), `page`, `pageSize`. |
+| `getPortForwardingStatus` | Gets port forwarding status and rules. Required: `type` (`user` or `upnp`). Optional: `page` (default 1), `pageSize` (default 50). |
 | `getLanNetworkList` | [DEPRECATED] Use `getLanNetworkListV2` instead. This tool aggregates all pages; getLanNetworkListV2 is explicitly paginated. |
 | `getLanNetworkListV2` | Get the LAN network list using the v2 API, with richer VLAN and DHCP data (paginated). |
 | `getInterfaceLanNetwork` | Gets interface-level LAN network bindings. Optional type filter. |
@@ -402,7 +402,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getIspLoad` | Gets per-WAN ISP link load over a time range. Requires `start` and `end` timestamps (seconds). |
 | `getChannels` | Gets channel distribution and utilization across all APs. |
 | `getInterference` | Gets top RF interference sources detected by APs. |
-| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics. Required: `type` (`ipsec`, `openvpn`, or `wireguard`). |
+| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics. Required: `type` (integer: `0` = Server, `1` = Client). |
 | `getGridDashboardIpsecTunnelStats` | Gets IPsec tunnel statistics.                                 |
 | `getGridDashboardOpenVpnTunnelStats` | Gets OpenVPN tunnel statistics by type. Requires `type` parameter. |
 

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getWanHealthDetail` | [DEPRECATED] Alias for the WAN health tool; kept for backward compatibility. Requires `gatewayMac`. |
 | `getWanUsageStats` | [DEPRECATED] Use `getDashboardTrafficActivities` instead. Gets WAN traffic usage statistics for the site. |
 | `getWanNatConfig` | Gets one-to-one NAT rules (paginated). |
-| `getPortForwardingStatus` | Gets port forwarding status and rules. Required: `type` (`user` or `upnp`), `page`, `pageSize`. |
+| `getPortForwardingStatus` | Gets port forwarding status and rules. Required: `type` (`user` or `upnp`). Optional pagination: `page` (default 1), `pageSize` (default 10). |
 | `getLanNetworkList` | [DEPRECATED] Use `getLanNetworkListV2` instead. This tool aggregates all pages; getLanNetworkListV2 is explicitly paginated. |
 | `getLanNetworkListV2` | Get the LAN network list using the v2 API, with richer VLAN and DHCP data (paginated). |
 | `getInterfaceLanNetwork` | Gets interface-level LAN network bindings. Optional type filter (0=WAN, 1=LAN). |
@@ -566,7 +566,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 
 | Tool              | Description                                               |
 | ----------------- | --------------------------------------------------------- |
-| `getThreatList` | Gets global threat management list. Required: `archived` (bool), `startTime`/`endTime` (ms epoch), `page`, `pageSize`. Optional: `severity` (0=low, 1=medium, 2=high, 3=critical). |
+| `getThreatList` | Gets global threat management list. Required: `archived` (bool). Optional: `startTime`/`endTime` (seconds since epoch), `severity` (0=Critical, 1=Major, 2=Moderate/Concerning, 3=Minor, 4=Low), `page`, `pageSize`. |
 | `getTopThreats` | Gets top threats from the global threat management view. |
 ### Dashboard / Monitor
 
@@ -586,7 +586,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getIspLoad` | Gets per-WAN ISP link load over a time range. Requires `start` and `end` timestamps (seconds). |
 | `getChannels` | Gets channel distribution and utilization across all APs. |
 | `getInterference` | Gets top RF interference sources detected by APs. |
-| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics. Required: `type` (`ipsec`, `openvpn`, or `wireguard`). |
+| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics. Required: `type` (0 = Server, 1 = Client). |
 | `getGridDashboardIpsecTunnelStats` | Gets IPsec tunnel statistics.                            |
 | `getGridDashboardOpenVpnTunnelStats` | Gets OpenVPN tunnel statistics by type. Requires `type` parameter. |
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Each token is `<category>[:<suffix>]`. Permission suffixes:
 
 ##### Category Reference
 
-Categories marked with `*` are reserved for upcoming phases and have no tool implementations yet. Specifying them will produce a startup warning and they will be skipped.
+Categories marked with `*` are reserved for upcoming phases and have no tool implementations yet. Specifying them will produce a startup warning and they will be skipped. Write tools are currently limited to the `clients` category.
 
 | Group                   | Categories                                                                    |
 | ----------------------- | ----------------------------------------------------------------------------- |
@@ -130,9 +130,9 @@ Categories marked with `*` are reserved for upcoming phases and have no tool imp
 | Network                 | `network-wan`, `network-sim-lte`*, `network-lan`, `network-routing`, `network-nat`, `network-services` |
 | Firewall & Security     | `firewall-acl`, `firewall-traffic`, `firewall-ids`, `security-threat`, `security-wids` |
 | VPN                     | `vpn`                                                                         |
-| Profiles & Schedules    | `profiles`, `schedules`*, `auth-profiles`                                     |
+| Profiles & Schedules    | `profiles`, `schedules`, `auth-profiles`                                     |
 | Logs                    | `logs`                                                                        |
-| Controller & Org        | `controller`, `sites`, `maintenance`*, `account-users`*, `account-sso`*, `account-cloud`* |
+| Controller & Org        | `controller`, `sites`, `maintenance`, `account-users`, `account-sso`*, `account-cloud` |
 | Hotspot                 | `hotspot-portal`*, `hotspot-vouchers`*, `hotspot-users`*                      |
 | Niche                   | `site-templates`*, `voip`*, `olt`*, `msp`*                                    |
 
@@ -473,7 +473,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getWanHealthDetail` | [DEPRECATED] Alias for the WAN health tool; kept for backward compatibility. Requires `gatewayMac`. |
 | `getWanUsageStats` | [DEPRECATED] Use `getDashboardTrafficActivities` instead. Gets WAN traffic usage statistics for the site. |
 | `getWanNatConfig` | Gets one-to-one NAT rules (paginated). |
-| `getPortForwardingStatus` | Gets port forwarding status and rules (User or UPnP types). |
+| `getPortForwardingStatus` | Gets port forwarding status and rules. Required: `type` (`user` or `upnp`), `page`, `pageSize`. |
 | `getLanNetworkList` | [DEPRECATED] Use `getLanNetworkListV2` instead. This tool aggregates all pages; getLanNetworkListV2 is explicitly paginated. |
 | `getLanNetworkListV2` | Get the LAN network list using the v2 API, with richer VLAN and DHCP data (paginated). |
 | `getInterfaceLanNetwork` | Gets interface-level LAN network bindings. Optional type filter (0=WAN, 1=LAN). |
@@ -484,7 +484,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getMulticastRateLimit` | Get multicast rate limit settings for a site. |
 | `getWlanGroupList` | Gets the list of WLAN groups configured in a site. |
 | `getSsidList` | Gets the list of SSIDs in a WLAN group. |
-| `getSsidDetail` | Gets detailed information for a specific SSID. |
+| `getSsidDetail` | Gets detailed information for a specific SSID. Required: `wlanId` and `ssidId`. |
 | `listAllSsids` | Lists wireless SSIDs across all WLAN groups. |
 | `getFirewallSetting` | Gets firewall configuration and rules for a site. |
 | `getVpnSettings` | Gets VPN settings for a site. |
@@ -566,7 +566,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 
 | Tool              | Description                                               |
 | ----------------- | --------------------------------------------------------- |
-| `getThreatList` | Gets global threat management list with filtering. |
+| `getThreatList` | Gets global threat management list. Required: `archived` (bool), `startTime`/`endTime` (ms epoch), `page`, `pageSize`. Optional: `severity` (0=low, 1=medium, 2=high, 3=critical). |
 | `getTopThreats` | Gets top threats from the global threat management view. |
 ### Dashboard / Monitor
 
@@ -586,7 +586,7 @@ In client-credentials mode the server already treats `Mcp-Session-Id` as optiona
 | `getIspLoad` | Gets per-WAN ISP link load over a time range. Requires `start` and `end` timestamps (seconds). |
 | `getChannels` | Gets channel distribution and utilization across all APs. |
 | `getInterference` | Gets top RF interference sources detected by APs. |
-| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics by type. Requires `type` parameter. |
+| `getGridDashboardTunnelStats` | Gets VPN tunnel statistics. Required: `type` (`ipsec`, `openvpn`, or `wireguard`). |
 | `getGridDashboardIpsecTunnelStats` | Gets IPsec tunnel statistics.                            |
 | `getGridDashboardOpenVpnTunnelStats` | Gets OpenVPN tunnel statistics by type. Requires `type` parameter. |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import './env.js';
+import pkg from '../package.json' with { type: 'json' };
 import type { OmadaConnectionConfig } from './config.js';
 import { loadConfigFromEnv } from './config.js';
 import { OmadaClient } from './omadaClient/index.js';
@@ -14,6 +15,18 @@ async function main(): Promise<void> {
 
     // Initialize logger with configured level, format, and output stream
     initLogger(config.logLevel, config.logFormat, useStderr);
+
+    // Startup banner
+    logger.info('Starting Omada MCP server', {
+        name: pkg.name,
+        version: pkg.version,
+        description: pkg.description,
+        mode: config.useHttp ? 'http' : 'stdio',
+        logLevel: config.logLevel,
+        nodeVersion: process.version,
+        platform: process.platform,
+        arch: process.arch,
+    });
 
     for (const warning of config.startupWarnings) {
         logger.warn(warning);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -80,6 +80,10 @@ describe('src/index main entry', () => {
         expect(OmadaClient).toHaveBeenCalledWith(expect.objectContaining({ baseUrl: 'https://controller.local' }));
         expect(startStdioServer).toHaveBeenCalledWith(expect.objectContaining({ client: 'instance' }), new Map());
         expect(startHttpServer).not.toHaveBeenCalled();
+        expect(loggerInfo).toHaveBeenCalledWith(
+            'Starting Omada MCP server',
+            expect.objectContaining({ name: 'tplink-omada-mcp', version: expect.any(String), mode: 'stdio' }),
+        );
         expect(loggerInfo).toHaveBeenCalledWith('Loaded Omada configuration', expect.objectContaining({ omadacId: 'omada-1' }));
     });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -82,7 +82,7 @@ describe('src/index main entry', () => {
         expect(startHttpServer).not.toHaveBeenCalled();
         expect(loggerInfo).toHaveBeenCalledWith(
             'Starting Omada MCP server',
-            expect.objectContaining({ name: 'tplink-omada-mcp', version: expect.any(String), mode: 'stdio' }),
+            expect.objectContaining({ name: 'tplink-omada-mcp', version: expect.any(String), mode: 'stdio' })
         );
         expect(loggerInfo).toHaveBeenCalledWith('Loaded Omada configuration', expect.objectContaining({ omadacId: 'omada-1' }));
     });


### PR DESCRIPTION
Part 2 of #84.

## Changes

### Stale category markers removed
Categories now implemented that were still marked `*` (future/reserved):
- `schedules` — remove `*`
- `maintenance` — remove `*`
- `account-users` — remove `*`
- `account-cloud` — remove `*`

Still correctly marked `*` (no tools yet): `insights`, `account-sso`, `network-sim-lte`, hotspot categories, `voip`, `olt`, `msp`

### Write-only clarification
Added note: write tools are currently limited to the `clients` category.

### Missing required parameter docs
| Tool | Added |
|---|---|
| `getThreatList` | `archived`, optional `startTime`/`endTime` (seconds since epoch), `page`, `pageSize`, `severity` enum (0=Critical, 1=Major, 2=Moderate/Concerning, 3=Minor, 4=Low) |
| `getSsidDetail` | Both `wlanId` and `ssidId` are required |
| `getPortForwardingStatus` | `type` (`user`/`upnp`) required; `page`, `pageSize` optional (pagination defaults) |
| `getGridDashboardTunnelStats` | `type` integer: 0 = Server, 1 = Client |

### Not done (Node.js version)
Audit suggested changing `24+` to `22 LTS` — but Dockerfile, CI, and package.json all target Node 24. The README is correct.

## Checklist
- [x] `npm run check` ✅
- [x] `node scripts/check-readme-sync.mjs` ✅