### PR TITLE
fix: improve siteId discoverability in listSites and searchDevices descriptions

### DIFF
--- a/src/tools/listSites.ts
+++ b/src/tools/listSites.ts
@@ -12,7 +12,8 @@ export function registerListSitesTool(server: McpServer, client: OmadaClient): v
     server.registerTool(
         'listSites',
         {
-            description: 'List all sites configured on the Omada controller.',
+            description:
+                "List all sites on the Omada controller. Returns each site's siteId and name. Call this first — the siteId value is required by most other tools. Without it, site-scoped tools will fail unless OMADA_SITE_ID is set in the environment.",
             inputSchema: inputSchema.shape,
         },
         wrapToolHandler('listSites', async ({ customHeaders }) => toToolResult(await client.listSites(customHeaders)))

--- a/src/tools/searchDevices.ts
+++ b/src/tools/searchDevices.ts
@@ -13,7 +13,8 @@ export function registerSearchDevicesTool(server: McpServer, client: OmadaClient
     server.registerTool(
         'searchDevices',
         {
-            description: 'Search for devices globally across all sites the user has access to. Returns devices matching the search key.',
+            description:
+                'Search for devices globally across all sites the user has access to. Returns devices matching the search key. The response also includes a siteNames map keyed by siteId — this can be used as a secondary way to discover site IDs (prefer listSites for that purpose).',
             inputSchema: inputSchema.shape,
         },
         wrapToolHandler('searchDevices', async ({ searchKey, customHeaders }) => toToolResult(await client.searchDevices(searchKey, customHeaders)))

--- a/tests/tools/listSites.test.ts
+++ b/tests/tools/listSites.test.ts
@@ -41,7 +41,8 @@ describe('tools/listSites', () => {
             expect(mockServer.registerTool).toHaveBeenCalledWith(
                 'listSites',
                 expect.objectContaining({
-                    description: 'List all sites configured on the Omada controller.',
+                    description:
+                        "List all sites on the Omada controller. Returns each site's siteId and name. Call this first — the siteId value is required by most other tools. Without it, site-scoped tools will fail unless OMADA_SITE_ID is set in the environment.",
                 }),
                 expect.any(Function)
             );


### PR DESCRIPTION
## Summary

- `listSites` description now explicitly tells the caller it must be invoked first to obtain the `siteId` required by most other tools, and that without it site-scoped tools will fail unless `OMADA_SITE_ID` is set in the environment.
- `searchDevices` description now surfaces the undocumented `siteNames` map in its response, noting it can be used as a secondary siteId discovery path (with `listSites` as the preferred method).

## Motivation

Users hit a bootstrapping problem: the MCP requires a `siteId` for most tools, but there was no signal in any tool description directing them to call `listSites` first. The `searchDevices` `siteNames` map was discovered only by accident and was completely undocumented.

## Test plan

- [ ] All 2108 existing tests pass (`npm run test:coverage`)
- [ ] Updated `tests/tools/listSites.test.ts` to match new description string
- [ ] Lint and build clean (`npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)