### PR TITLE
Add Fusion web auth and management tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,10 +48,18 @@
 # Example: https://omada-controller.local
 OMADA_BASE_URL=https://controller.example.com:8043
 
-# OAuth client credentials (required)
-# Generate these under Omada Platform Integration
+# Authentication mode: oauth (default) or web.
+# Use web for Fusion gateway/local web UI sessions when OpenAPI OAuth is unavailable.
+# OMADA_AUTH_MODE=oauth
+
+# OAuth client credentials (required when OMADA_AUTH_MODE=oauth)
+# Generate these under Omada Platform Integration.
 OMADA_CLIENT_ID=your-client-id
 OMADA_CLIENT_SECRET=your-client-secret
+
+# Web UI credentials (required when OMADA_AUTH_MODE=web)
+# OMADA_WEB_USERNAME=your-web-username
+# OMADA_WEB_PASSWORD=your-web-password
 
 # Omada controller ID (omadacId) to target (required)
 # Shown in the application details

--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,12 @@
 #   Niche:                site-templates*, voip*, olt*, msp*
 #
 # Examples:
-#   All read-only:                   OMADA_TOOL_CATEGORIES=all:r
-#   Default (safe read subset):      OMADA_TOOL_CATEGORIES=dashboard:r,client-insights:r,clients:r,devices-all:r
-#   Full access including writes:    OMADA_TOOL_CATEGORIES=all:rw
+#   Curated default tool set:        OMADA_TOOL_CATEGORIES=default
+#   Full read-only registry:         OMADA_TOOL_CATEGORIES=all:r
+#   Full registry incl. writes:      OMADA_TOOL_CATEGORIES=all
 #   Network read + client writes:    OMADA_TOOL_CATEGORIES=network-all:r,clients:rw
 #
-# OMADA_TOOL_CATEGORIES=dashboard:r,client-insights:r,clients:r,devices-all:r
+# OMADA_TOOL_CATEGORIES=default
 
 # ==============================================================================
 # Omada Client Configuration

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -89,8 +89,11 @@ The MCP server reads its configuration from environment variables.
 | Variable              | Required | Default | Description                                                                 |
 | --------------------- | -------- | ------- | --------------------------------------------------------------------------- |
 | `OMADA_BASE_URL` | Yes      | -       | Base URL of the Omada controller (e.g., `https://omada-controller.local`) |
-| `OMADA_CLIENT_ID` | Yes      | -       | OAuth client ID generated under Omada Platform Integration |
-| `OMADA_CLIENT_SECRET` | Yes      | -       | OAuth client secret associated with the client ID                           |
+| `OMADA_AUTH_MODE` | No       | `oauth` | Authentication mode: `oauth` or `web` |
+| `OMADA_CLIENT_ID` | OAuth   | -       | OAuth client ID generated under Omada Platform Integration |
+| `OMADA_CLIENT_SECRET` | OAuth   | -       | OAuth client secret associated with the client ID                           |
+| `OMADA_WEB_USERNAME` | Web     | -       | Omada web UI username for Fusion/local web-session auth |
+| `OMADA_WEB_PASSWORD` | Web     | -       | Omada web UI password for Fusion/local web-session auth |
 | `OMADA_OMADAC_ID` | Yes      | -       | Omada controller ID (omadacId) to target |
 | `OMADA_SITE_ID` | No       | -       | Optional default site ID; if omitted, each MCP call must pass a siteId |
 | `OMADA_STRICT_SSL` | No       | `true`  | Enforce strict SSL certificate validation (set to `false` for self-signed) |
@@ -102,7 +105,7 @@ The MCP server reads its configuration from environment variables.
 | `MCP_SERVER_LOG_LEVEL` | No       | `info`  | Logging verbosity (`debug`, `info`, `warn`, `error`, `silent`) |
 | `MCP_SERVER_LOG_FORMAT` | No       | `plain` | Log output format (`plain`, `json`, or `gcp-json`) |
 | `MCP_SERVER_USE_HTTP` | No       | `false` | Start HTTP server instead of stdio |
-> **Session IDs and authentication:** When `OMADA_CLIENT_ID`, `OMADA_CLIENT_SECRET`, and `OMADA_OMADAC_ID` are provided (the default client-credentials mode), the server runs statelessly and treats the `Mcp-Session-Id` header as optional. A future OAuth-based user authentication mode will require this header again.
+> **Session IDs and authentication:** In default `oauth` mode, provide `OMADA_CLIENT_ID`, `OMADA_CLIENT_SECRET`, and `OMADA_OMADAC_ID`. For Fusion gateways or controllers where OpenAPI OAuth is unavailable, set `OMADA_AUTH_MODE=web` and provide `OMADA_WEB_USERNAME`, `OMADA_WEB_PASSWORD`, and `OMADA_OMADAC_ID`. The HTTP transport also accepts matching `x-omada-auth-mode`, `x-omada-client-id`, `x-omada-client-secret`, `x-omada-web-username`, `x-omada-web-password`, and `x-omada-omadac-id` headers.
 
 ### MCP Server HTTP Configuration
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The MCP server reads its configuration from environment variables. See `.env.exa
 
 | Variable                  | Required | Default                                                      | Description                                          |
 | ------------------------- | -------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| `OMADA_TOOL_CATEGORIES` | No       | `dashboard:r,client-insights:r,clients:r,devices-all:r` | Comma-separated categories to enable at startup |
+| `OMADA_TOOL_CATEGORIES` | No       | `default` | Tool profile or comma-separated categories to enable at startup |
 Each token is `<category>[:<suffix>]`. Permission suffixes:
 
 | Suffix | Effect               |
@@ -119,7 +119,7 @@ Each token is `<category>[:<suffix>]`. Permission suffixes:
 
 ##### Category Reference
 
-Categories marked with `*` are reserved for upcoming phases and have no tool implementations yet. Specifying them will produce a startup warning and they will be skipped. Write tools are currently limited to the `clients` category.
+Use `default` for the curated practical tool set inherited from the original server. Use `all` for the complete generated registry. Categories marked with `*` are reserved for upcoming phases and have no tool implementations yet. Specifying them will produce a startup warning and they will be skipped.
 
 | Group                   | Categories                                                                    |
 | ----------------------- | ----------------------------------------------------------------------------- |
@@ -153,11 +153,11 @@ Examples:
 # Read-only access to everything
 OMADA_TOOL_CATEGORIES=all:r
 
-# Default safe subset (read only)
-OMADA_TOOL_CATEGORIES=dashboard:r,client-insights:r,clients:r,devices-all:r
+# Curated default tool set
+OMADA_TOOL_CATEGORIES=default
 
 # Full access including write operations
-OMADA_TOOL_CATEGORIES=all:rw
+OMADA_TOOL_CATEGORIES=all
 
 # Network read + client write operations
 OMADA_TOOL_CATEGORIES=network-all:r,clients:rw

--- a/README.md
+++ b/README.md
@@ -168,8 +168,11 @@ OMADA_TOOL_CATEGORIES=network-all:r,clients:rw
 | Variable              | Required | Default | Description                                                                 |
 | --------------------- | -------- | ------- | --------------------------------------------------------------------------- |
 | `OMADA_BASE_URL` | Yes      | -       | Base URL of the Omada controller (e.g., `https://omada-controller.local`) |
-| `OMADA_CLIENT_ID` | Yes      | -       | OAuth client ID generated under Omada Platform Integration |
-| `OMADA_CLIENT_SECRET` | Yes      | -       | OAuth client secret associated with the client ID                           |
+| `OMADA_AUTH_MODE` | No       | `oauth` | Authentication mode: `oauth` or `web` |
+| `OMADA_CLIENT_ID` | OAuth   | -       | OAuth client ID generated under Omada Platform Integration |
+| `OMADA_CLIENT_SECRET` | OAuth   | -       | OAuth client secret associated with the client ID                           |
+| `OMADA_WEB_USERNAME` | Web     | -       | Omada web UI username for Fusion/local web-session auth |
+| `OMADA_WEB_PASSWORD` | Web     | -       | Omada web UI password for Fusion/local web-session auth |
 | `OMADA_OMADAC_ID` | Yes      | -       | Omada controller ID (omadacId) to target |
 | `OMADA_SITE_ID` | No       | -       | Optional default site ID; if omitted, each MCP call must pass a siteId |
 | `OMADA_STRICT_SSL` | No       | `true`  | Enforce strict SSL certificate validation (set to `false` for self-signed) |
@@ -181,7 +184,7 @@ OMADA_TOOL_CATEGORIES=network-all:r,clients:rw
 | `MCP_SERVER_LOG_LEVEL` | No       | `info`  | Logging verbosity (`debug`, `info`, `warn`, `error`, `silent`) |
 | `MCP_SERVER_LOG_FORMAT` | No       | `plain` | Log output format (`plain`, `json`, or `gcp-json`) |
 | `MCP_SERVER_USE_HTTP` | No       | `false` | Start HTTP server instead of stdio |
-> **Session IDs and authentication:** When `OMADA_CLIENT_ID`, `OMADA_CLIENT_SECRET`, and `OMADA_OMADAC_ID` are provided (the default client-credentials mode), the server runs statelessly and treats the `Mcp-Session-Id` header as optional. A future OAuth-based user authentication mode will require this header again.
+> **Session IDs and authentication:** In default `oauth` mode, provide `OMADA_CLIENT_ID`, `OMADA_CLIENT_SECRET`, and `OMADA_OMADAC_ID`. For Fusion gateways or controllers where OpenAPI OAuth is unavailable, set `OMADA_AUTH_MODE=web` and provide `OMADA_WEB_USERNAME`, `OMADA_WEB_PASSWORD`, and `OMADA_OMADAC_ID`. The HTTP transport also accepts matching `x-omada-auth-mode`, `x-omada-client-id`, `x-omada-client-secret`, `x-omada-web-username`, `x-omada-web-password`, and `x-omada-omadac-id` headers.
 
 #### MCP Server HTTP Configuration
 
@@ -1004,4 +1007,3 @@ The repository includes a ready-to-use [devcontainer](https://containers.dev/) c
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
-

--- a/SWITCH_PORT_SPEC.md
+++ b/SWITCH_PORT_SPEC.md
@@ -1,0 +1,57 @@
+# Switch Port Tools to Add
+
+Add these tools following existing patterns. All use OpenAPI v1.
+
+## Switch Info (already partially works via genericApiCall)
+1. **getSwitch** — GET `/sites/{siteId}/switches/{switchMac}` (v1)
+   - Returns full switch info including portList array
+
+## Single Port Operations
+2. **setSwitchPortProfile** — PUT `/sites/{siteId}/switches/{switchMac}/ports/{port}/profile`
+   - Body: `{"profileId": "string"}` — assigns a LAN profile to the port
+3. **setSwitchPortPoe** — PUT `/sites/{siteId}/switches/{switchMac}/ports/{port}/poe-mode`
+   - Body: `{"poeMode": number}` — 1=on(802.3at/af), 0=off
+4. **setSwitchPortName** — PUT `/sites/{siteId}/switches/{switchMac}/ports/{port}/name`
+   - Body: `{"name": "string"}` — 1-128 chars
+5. **setSwitchPortStatus** — PUT `/sites/{siteId}/switches/{switchMac}/ports/{port}/status`
+   - Body: `{"status": number}` — 0=off, 1=on
+6. **setSwitchPortProfileOverride** — PUT `/sites/{siteId}/switches/{switchMac}/ports/{port}/profile-override`
+   - Body: `{"profileOverrideEnable": boolean}`
+
+## Batch Port Operations
+7. **batchSetSwitchPortProfile** — PUT `/sites/{siteId}/switches/{switchMac}/multi-ports/profile-override`
+   - Body: `{"portList": [1,2,3], "profileOverrideEnable": boolean}`
+8. **batchSetSwitchPortPoe** — PUT `/sites/{siteId}/switches/{switchMac}/multi-ports/poe-mode`
+   - Body: `{"portList": [1,2,3], "poeMode": number}`
+9. **batchSetSwitchPortStatus** — PUT `/sites/{siteId}/switches/{switchMac}/multi-ports/status`
+   - Body: `{"portList": [1,2,3], "status": number}`
+10. **batchSetSwitchPortName** — PUT `/sites/{siteId}/switches/{switchMac}/multi-ports/name`
+    - Body: `{"portNameList": [{"port": 1, "name": "Office-Mac"}, ...]}`
+
+## Cable Test
+11. **startCableTest** — POST `/sites/{siteId}/cable-test/switches/{switchMac}/start`
+12. **getCableTestResults** — GET `/sites/{siteId}/cable-test/switches/{switchMac}/full-results`
+
+## Switch Networks (VLAN trunking)
+13. **getSwitchNetworks** — GET `/sites/{siteId}/switches/{switchMac}/networks`
+14. **setSwitchNetworks** — POST `/sites/{siteId}/switches/{switchMac}/networks`
+
+## Implementation
+- Add methods to a new `SwitchOperations` class in `src/omadaClient/switch.ts`
+- Wire into OmadaClient
+- Create tool files in `src/tools/`
+- Register in `src/tools/index.ts`
+- All tools: siteId optional, switchMac required, port required for single-port ops
+- Build must pass
+- Commit: `feat: add switch port management tools`
+
+## Also: Update README.md
+Replace the existing README with a clean one showing:
+- Project name: "Omada MCP Server" (not the original repo name)
+- Description: Full CRUD MCP server for TP-Link Omada Controller
+- Quick start (stdio via node, env vars)
+- Docker usage
+- Full tool list grouped by category (Read, Write, Actions, Switch Ports, Generic)
+- Show the 45 existing + new switch port tools
+- Credit original repo as upstream
+- Our repo: realtydev/omada-mcp

--- a/WRITE_TOOLS_SPEC.md
+++ b/WRITE_TOOLS_SPEC.md
@@ -1,0 +1,91 @@
+# Write Tools to Add
+
+Add write/action tools to this existing MCP server. Follow the existing code patterns exactly (tool registration in src/tools/, operations in src/omadaClient/).
+
+## API Info
+- Auth: already handled by AuthManager
+- Base path: `buildOmadaPath()` for v1, `buildOmadaPath(path, 'v2')` for v2
+- RequestHandler has `.get()` and `.request()` methods
+- All write ops use the same `Authorization: AccessToken=xxx` header
+
+## New Tools to Add
+
+### Network Management (write)
+1. **createLanNetwork** — POST `/sites/{siteId}/lan-networks` (v2)
+   - Params: name, vlan (number), gatewaySubnet (e.g. "192.168.10.1/24"), purpose (1=interface), igmpSnoopEnable (bool), dhcpSettings (enable, ipRangeStart, ipRangeEnd, leaseTime)
+   - All fields required by controller validation
+
+2. **updateLanNetwork** — PUT `/sites/{siteId}/lan-networks/{networkId}` (v2)
+   - Same fields as create + networkId
+
+3. **deleteLanNetwork** — DELETE `/sites/{siteId}/lan-networks/{networkId}` (v2)
+
+4. **createLanProfile** — POST `/sites/{siteId}/lan-profiles` (v1)
+   - Params: name, nativeNetworkId, tagNetworkIds[], poe, spanningTreeEnable, loopbackDetectEnable, portIsolationEnable, lldpMedEnable
+
+5. **updateLanProfile** — PUT `/sites/{siteId}/lan-profiles/{profileId}` (v1)
+
+### Device Actions
+6. **rebootDevice** — POST `/sites/{siteId}/devices/{deviceMac}/reboot` (v1) (ref: wonjo-linc/MCP-Omada)
+7. **adoptDevice** — POST `/sites/{siteId}/cmd/adopts` body: `{macs: [deviceMac]}` (v1)
+
+### Client Actions
+8. **blockClient** — POST `/sites/{siteId}/clients/{clientMac}/block` (v1)
+9. **unblockClient** — POST `/sites/{siteId}/clients/{clientMac}/unblock` (v1)
+
+### Firewall
+10. **updateFirewallSetting** — PUT `/sites/{siteId}/firewall` (v1)
+    - Accepts the same shape returned by getFirewallSetting (broadcastPing, sendRedirects, synCookies, etc.)
+
+### Generic Escape Hatch
+11. **genericApiCall** — Execute any Omada API call
+    - Params: method (GET/POST/PUT/PATCH/DELETE), path (relative, e.g. "/sites/{siteId}/setting/firewall/acls"), version (v1/v2, default v1), body (optional JSON), queryParams (optional record)
+    - This is the power tool for anything not explicitly covered
+
+### Monitoring (read, from wonjo reference)
+12. **listEvents** — GET `/sites/{siteId}/events` (v1, paginated)
+13. **listLogs** — GET `/sites/{siteId}/logs` (v1, paginated)
+
+### Switch Port Management (from tplink-omada-api reference)
+14. **getSwitchPorts** — GET `/sites/{siteId}/switches/{switchMac}/ports` (v1, paginated)
+    - Returns all ports with status, profile, PoE, link speed, STP state
+15. **updateSwitchPort** — PATCH `/sites/{siteId}/switches/{switchMac}/ports/{portId}` (v1)
+    - Params: profileId, poe (enable/disable), bandwidthLimitMode, linkSpeed, duplex, spanningTreeEnable, portIsolationEnable, loopbackDetectEnable, lldpMedEnable
+
+### Client Management
+16. **reconnectClient** — POST `/sites/{siteId}/clients/{clientMac}/reconnect` (v1)
+17. **updateClient** — PATCH `/sites/{siteId}/clients/{clientMac}` (v1)
+    - Params: name (display name), fixedIp (static DHCP), rateLimitEnable, upLimit, downLimit
+
+### Device Management
+18. **setDeviceLed** — POST or PATCH `/sites/{siteId}/devices/{deviceMac}/led-setting` (v1)
+    - Params: ledSetting (0=off, 1=on, 2=site-default)
+19. **getFirmwareDetails** — GET `/sites/{siteId}/devices/{deviceMac}/firmware` (v1)
+20. **startFirmwareUpgrade** — POST `/sites/{siteId}/devices/{deviceMac}/firmware/upgrade` (v1)
+
+### Gateway WAN Management
+21. **setGatewayWanConnect** — POST `/sites/{siteId}/gateways/{gatewayMac}/wan/{portId}/connect` or `/disconnect` (v1)
+    - Params: gatewayMac, portId, action (connect/disconnect)
+
+### Firewall ACL Rules
+22. **listFirewallAcls** — GET `/sites/{siteId}/setting/firewall/acls` (v1)
+23. **createFirewallAcl** — POST `/sites/{siteId}/setting/firewall/acls` (v1)
+    - For inter-VLAN isolation rules
+24. **deleteFirewallAcl** — DELETE `/sites/{siteId}/setting/firewall/acls/{aclId}` (v1)
+
+### Static Routes
+25. **listRoutes** — GET `/sites/{siteId}/setting/routes` (v1)
+
+NOTE: Some of these endpoint paths are from the older non-OpenAPI style. They may need the path format `/sites/{siteId}/...` under `/openapi/v1/{omadacId}/`. If a call returns 404, try the genericApiCall to discover the correct path. The genericApiCall tool is the safety net.
+
+## Implementation Notes
+- Add new operation classes: `ActionOperations` (device/client actions) in `src/omadaClient/action.ts`
+- Add write methods to existing `NetworkOperations` in `src/omadaClient/network.ts`
+- Add `GenericOperations` in `src/omadaClient/generic.ts`
+- Register tools in new files under `src/tools/` following existing patterns
+- Wire everything through `OmadaClient` in `src/omadaClient/index.ts`
+- Add RequestHandler methods: `.post(path, data, params?)`, `.put(path, data, params?)`, `.delete(path, params?)`
+- siteId should be optional on ALL tools (resolved via SiteOperations.resolveSiteId)
+- Use zod for input validation (already a dependency)
+- Mark write tools with `destructiveHint: true` in annotations
+- Build must pass: `npm run build`

--- a/src/config.ts
+++ b/src/config.ts
@@ -233,8 +233,11 @@ const envSchema = z
 
         // Omada Client Configuration
         baseUrl: z.string().url({ message: 'OMADA_BASE_URL must be a valid URL' }),
+        authMode: z.enum(['oauth', 'web']).optional().default('oauth'),
         clientId: z.string().min(1, 'OMADA_CLIENT_ID must not be empty').optional(),
         clientSecret: z.string().min(1, 'OMADA_CLIENT_SECRET must not be empty').optional(),
+        webUsername: z.string().min(1, 'OMADA_WEB_USERNAME must not be empty').optional(),
+        webPassword: z.string().min(1, 'OMADA_WEB_PASSWORD must not be empty').optional(),
         omadacId: z.string().min(1, 'OMADA_OMADAC_ID must not be empty').optional(),
         siteId: z.string().min(1).optional(),
         strictSsl: createBooleanStringSchema(true),
@@ -256,10 +259,21 @@ const envSchema = z
         httpNgrokEnabled: createBooleanStringSchema(false),
         httpNgrokAuthToken: z.string().optional(),
     })
-    .refine((data) => data.useHttp || !!data.clientId, { message: 'OMADA_CLIENT_ID is required when not using HTTP mode', path: ['clientId'] })
-    .refine((data) => data.useHttp || !!data.clientSecret, {
+    .refine((data) => data.useHttp || data.authMode !== 'oauth' || !!data.clientId, {
+        message: 'OMADA_CLIENT_ID is required for OAuth auth when not using HTTP mode',
+        path: ['clientId'],
+    })
+    .refine((data) => data.useHttp || data.authMode !== 'oauth' || !!data.clientSecret, {
         message: 'OMADA_CLIENT_SECRET is required when not using HTTP mode',
         path: ['clientSecret'],
+    })
+    .refine((data) => data.useHttp || data.authMode !== 'web' || !!data.webUsername, {
+        message: 'OMADA_WEB_USERNAME is required for web auth when not using HTTP mode',
+        path: ['webUsername'],
+    })
+    .refine((data) => data.useHttp || data.authMode !== 'web' || !!data.webPassword, {
+        message: 'OMADA_WEB_PASSWORD is required for web auth when not using HTTP mode',
+        path: ['webPassword'],
     })
     .refine((data) => data.useHttp || !!data.omadacId, { message: 'OMADA_OMADAC_ID is required when not using HTTP mode', path: ['omadacId'] })
     .refine(
@@ -302,8 +316,11 @@ const envSchema = z
  */
 export interface OmadaConnectionConfig {
     baseUrl: string;
-    clientId: string;
-    clientSecret: string;
+    authMode: 'oauth' | 'web';
+    clientId?: string;
+    clientSecret?: string;
+    webUsername?: string;
+    webPassword?: string;
     omadacId: string;
     siteId?: string;
     strictSsl: boolean;
@@ -319,8 +336,11 @@ export interface EnvironmentConfig {
     // baseUrl is always required (from env)
     // clientId, clientSecret, omadacId are optional in HTTP mode (can come from request headers)
     baseUrl: string;
+    authMode: 'oauth' | 'web';
     clientId?: string;
     clientSecret?: string;
+    webUsername?: string;
+    webPassword?: string;
     omadacId?: string;
     siteId?: string;
     strictSsl: boolean;
@@ -351,8 +371,11 @@ export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Environ
 
         // Omada Client Configuration
         baseUrl: env.OMADA_BASE_URL,
+        authMode: env.OMADA_AUTH_MODE,
         clientId: env.OMADA_CLIENT_ID,
         clientSecret: env.OMADA_CLIENT_SECRET,
+        webUsername: env.OMADA_WEB_USERNAME,
+        webPassword: env.OMADA_WEB_PASSWORD,
         omadacId: env.OMADA_OMADAC_ID,
         siteId: env.OMADA_SITE_ID,
         strictSsl: env.OMADA_STRICT_SSL,
@@ -407,8 +430,11 @@ export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Environ
 
         // Omada Client Configuration
         baseUrl: parsed.data.baseUrl.replace(/\/$/, ''),
+        authMode: parsed.data.authMode,
         clientId: parsed.data.clientId,
         clientSecret: parsed.data.clientSecret,
+        webUsername: parsed.data.webUsername,
+        webPassword: parsed.data.webPassword,
         omadacId: parsed.data.omadacId,
         siteId: parsed.data.siteId,
         strictSsl: parsed.data.strictSsl,

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,8 +93,16 @@ export interface ActiveCategoryEntry {
     permissions: Set<ToolPermission>;
 }
 
+export type ToolProfile = 'default';
+
+export interface ToolFilter {
+    categories: Map<ToolCategory, Set<ToolPermission>>;
+    profiles: Set<ToolProfile>;
+}
+
 export interface ParseToolCategoriesResult {
     categories: Map<ToolCategory, Set<ToolPermission>>;
+    profiles: Set<ToolProfile>;
     warnings: string[];
 }
 
@@ -108,6 +116,7 @@ export interface ParseToolCategoriesResult {
  *   - no suffix    → read and write (`:rw`)
  *
  * Group aliases (e.g. `all`, `devices-all`) are expanded before the suffix is applied.
+ * The `default` profile registers the curated practical tool set from the original server.
  * Unknown category names produce a warning and are skipped.
  * Future (unimplemented) categories produce a warning and are skipped.
  *
@@ -115,6 +124,7 @@ export interface ParseToolCategoriesResult {
  */
 export function parseToolCategories(raw: string): ParseToolCategoriesResult {
     const categories = new Map<ToolCategory, Set<ToolPermission>>();
+    const profiles = new Set<ToolProfile>();
     const warnings: string[] = [];
 
     const tokens = raw
@@ -153,6 +163,11 @@ export function parseToolCategories(raw: string): ParseToolCategoriesResult {
             permissions.add('write');
         }
 
+        if (name === 'default') {
+            profiles.add('default');
+            continue;
+        }
+
         // Expand group aliases
         if (name in CATEGORY_GROUP_ALIASES) {
             for (const cat of CATEGORY_GROUP_ALIASES[name]) {
@@ -182,7 +197,7 @@ export function parseToolCategories(raw: string): ParseToolCategoriesResult {
         mergePermissions(categories, name as ToolCategory, permissions);
     }
 
-    return { categories, warnings };
+    return { categories, profiles, warnings };
 }
 
 function mergePermissions(map: Map<ToolCategory, Set<ToolPermission>>, cat: ToolCategory, perms: Set<ToolPermission>): void {
@@ -195,7 +210,7 @@ function mergePermissions(map: Map<ToolCategory, Set<ToolPermission>>, cat: Tool
 }
 
 /** Default value for OMADA_TOOL_CATEGORIES */
-export const DEFAULT_TOOL_CATEGORIES = 'dashboard:r,client-insights:r,clients:r,devices-all:r';
+export const DEFAULT_TOOL_CATEGORIES = 'default';
 
 const createBooleanStringSchema = (
     defaultValue: boolean
@@ -329,7 +344,7 @@ export interface OmadaConnectionConfig {
 
 export interface EnvironmentConfig {
     // Tool category filtering
-    toolCategories: Map<ToolCategory, Set<ToolPermission>>;
+    toolCategories: ToolFilter;
     startupWarnings: string[];
 
     // Omada Client Configuration
@@ -420,12 +435,12 @@ export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Environ
     }
 
     // Parse tool categories
-    const { categories: toolCategories, warnings: categoryWarnings } = parseToolCategories(parsed.data.toolCategories);
+    const { categories, profiles, warnings: categoryWarnings } = parseToolCategories(parsed.data.toolCategories);
     warnings.push(...categoryWarnings);
 
     return {
         // Tool category filtering
-        toolCategories,
+        toolCategories: { categories, profiles },
         startupWarnings: warnings,
 
         // Omada Client Configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ async function main(): Promise<void> {
 
     logger.info('Loaded Omada configuration', {
         baseUrl: config.baseUrl,
+        authMode: config.authMode,
         omadacId: config.omadacId ?? '(from headers)',
         siteId: config.siteId ?? null,
         strictSsl: config.strictSsl,
@@ -46,8 +47,11 @@ async function main(): Promise<void> {
         // In stdio mode, the three credential fields are validated as required by loadConfigFromEnv
         const omadaConfig: OmadaConnectionConfig = {
             baseUrl: config.baseUrl,
-            clientId: config.clientId as string,
-            clientSecret: config.clientSecret as string,
+            authMode: config.authMode,
+            clientId: config.clientId,
+            clientSecret: config.clientSecret,
+            webUsername: config.webUsername,
+            webPassword: config.webPassword,
             omadacId: config.omadacId as string,
             siteId: config.siteId,
             strictSsl: config.strictSsl,

--- a/src/omadaClient/action.ts
+++ b/src/omadaClient/action.ts
@@ -1,0 +1,118 @@
+import type { OmadaApiResponse } from '../types/index.js';
+
+import type { RequestHandler } from './request.js';
+import type { SiteOperations } from './site.js';
+
+/**
+ * Device and client action operations for the Omada API.
+ * Covers reboot, adopt, block, and unblock actions.
+ */
+export class ActionOperations {
+    constructor(
+        private readonly request: RequestHandler,
+        private readonly site: SiteOperations,
+        private readonly buildPath: (path: string, version?: string) => string
+    ) {}
+
+    /**
+     * Reboot a device by MAC address (v1 API).
+     */
+    public async rebootDevice(deviceMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/devices/${encodeURIComponent(deviceMac)}/reboot`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, {});
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Adopt a device by MAC address (v1 API).
+     */
+    public async adoptDevice(deviceMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/cmd/adopts`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, { macs: [deviceMac] });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Block a client by MAC address (v1 API).
+     */
+    public async blockClient(clientMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/clients/${encodeURIComponent(clientMac)}/block`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, {});
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Unblock a client by MAC address (v1 API).
+     */
+    public async unblockClient(clientMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/clients/${encodeURIComponent(clientMac)}/unblock`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, {});
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Reconnect a client by MAC address (v1 API).
+     */
+    public async reconnectClient(clientMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/clients/${encodeURIComponent(clientMac)}/reconnect`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, {});
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Update a client's settings (v1 API).
+     */
+    public async updateClient(clientMac: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/clients/${encodeURIComponent(clientMac)}`);
+        const response = await this.request.request<OmadaApiResponse<unknown>>({ method: 'PATCH', url: path, data });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Set device LED setting (v1 API).
+     */
+    public async setDeviceLed(deviceMac: string, ledSetting: number, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/devices/${encodeURIComponent(deviceMac)}/led-setting`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, { ledSetting });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get firmware details for a device (v1 API).
+     */
+    public async getFirmwareDetails(deviceMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/devices/${encodeURIComponent(deviceMac)}/firmware`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Start firmware upgrade for a device (v1 API).
+     */
+    public async startFirmwareUpgrade(deviceMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/devices/${encodeURIComponent(deviceMac)}/firmware/upgrade`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, {});
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Connect or disconnect a gateway WAN port (v1 API).
+     */
+    public async setGatewayWanConnect(gatewayMac: string, portId: string, action: 'connect' | 'disconnect', siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(
+            `/sites/${encodeURIComponent(resolvedSiteId)}/gateways/${encodeURIComponent(gatewayMac)}/wan/${encodeURIComponent(portId)}/${action}`
+        );
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, {});
+        return this.request.ensureSuccess(response);
+    }
+}

--- a/src/omadaClient/auth.ts
+++ b/src/omadaClient/auth.ts
@@ -5,10 +5,17 @@ import { logger } from '../utils/logger.js';
 
 const TOKEN_EXPIRY_BUFFER_SECONDS = 30;
 
+export type AuthMode = 'oauth' | 'web';
+
+export interface RequestAuthManager {
+    getAuthHeaders(): Promise<Record<string, string>>;
+    clearToken(): void;
+}
+
 /**
  * Authentication state management for the Omada client.
  */
-export class AuthManager {
+export class AuthManager implements RequestAuthManager {
     private accessToken?: string;
 
     private refreshToken?: string;
@@ -28,6 +35,11 @@ export class AuthManager {
     public async getAccessToken(): Promise<string> {
         await this.ensureAccessToken();
         return this.accessToken ?? '';
+    }
+
+    public async getAuthHeaders(): Promise<Record<string, string>> {
+        const accessToken = await this.getAccessToken();
+        return { Authorization: `AccessToken=${accessToken}` };
     }
 
     /**
@@ -112,5 +124,93 @@ export class AuthManager {
         const expiresInSeconds = Number.isFinite(token.expiresIn) ? token.expiresIn : 0;
         const expiresInMs = Math.max(expiresInSeconds - TOKEN_EXPIRY_BUFFER_SECONDS, 0) * 1000;
         this.tokenExpiresAt = Date.now() + expiresInMs;
+    }
+}
+
+/**
+ * Fusion gateway web-session authentication for OpenAPI requests.
+ */
+export class WebAuthManager implements RequestAuthManager {
+    private csrfToken?: string;
+
+    private sessionCookie?: string;
+
+    constructor(
+        private readonly http: AxiosInstance,
+        private readonly username: string,
+        private readonly password: string,
+        private readonly omadacId: string
+    ) {}
+
+    public async getAuthHeaders(): Promise<Record<string, string>> {
+        await this.ensureSession();
+
+        const headers: Record<string, string> = {
+            'Csrf-Token': this.csrfToken ?? '',
+            'Omada-Request-Source': 'web-local',
+        };
+
+        if (this.sessionCookie) {
+            headers.Cookie = this.sessionCookie;
+        }
+
+        return headers;
+    }
+
+    public clearToken(): void {
+        this.csrfToken = undefined;
+        this.sessionCookie = undefined;
+    }
+
+    private async ensureSession(): Promise<void> {
+        if (this.csrfToken) {
+            return;
+        }
+
+        await this.login();
+    }
+
+    private async login(): Promise<void> {
+        const loginPath = `/${encodeURIComponent(this.omadacId)}/api/v2/login`;
+
+        try {
+            const response = await this.http.post(loginPath, { username: this.username, password: this.password }, { withCredentials: true });
+            const data = response.data as { errorCode?: number; msg?: string; result?: { token?: string } };
+
+            if (data.errorCode !== 0) {
+                logger.error('Omada web authentication error', {
+                    errorCode: data.errorCode,
+                    message: data.msg,
+                });
+                throw new Error(data.msg ?? 'Omada web authentication failed');
+            }
+
+            const token = data.result?.token;
+            if (!token) {
+                throw new Error('Omada web authentication succeeded but no CSRF token returned');
+            }
+
+            this.csrfToken = token;
+            this.sessionCookie = this.extractSessionCookie(response.headers['set-cookie']);
+
+            logger.info('Omada web authentication successful');
+        } catch (error) {
+            logger.error('Omada web authentication failed', {
+                baseUrl: this.http.defaults.baseURL,
+                error: error instanceof Error ? error.message : String(error),
+            });
+            throw error;
+        }
+    }
+
+    private extractSessionCookie(setCookieHeader: unknown): string | undefined {
+        if (!setCookieHeader) {
+            return undefined;
+        }
+
+        const headers = Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader];
+        const cookies = headers.map((cookie) => String(cookie).split(';')[0].trim()).filter(Boolean);
+
+        return cookies.length > 0 ? cookies.join('; ') : undefined;
     }
 }

--- a/src/omadaClient/generic.ts
+++ b/src/omadaClient/generic.ts
@@ -1,0 +1,31 @@
+import type { RequestHandler } from './request.js';
+
+/**
+ * Generic API operations for the Omada API.
+ * Provides an escape hatch for any API call not explicitly covered.
+ */
+export class GenericOperations {
+    constructor(
+        private readonly request: RequestHandler,
+        private readonly buildPath: (path: string, version?: string) => string
+    ) {}
+
+    /**
+     * Execute an arbitrary Omada API call.
+     */
+    public async genericApiCall(
+        method: string,
+        path: string,
+        version = 'v1',
+        body?: unknown,
+        queryParams?: Record<string, unknown>
+    ): Promise<unknown> {
+        const fullPath = this.buildPath(path, version);
+        return await this.request.request<unknown>({
+            method,
+            url: fullPath,
+            data: body,
+            params: queryParams,
+        });
+    }
+}

--- a/src/omadaClient/index.ts
+++ b/src/omadaClient/index.ts
@@ -22,13 +22,18 @@ import type {
     RateLimitProfile,
     ThreatInfo,
 } from '../types/index.js';
+import { logger } from '../utils/logger.js';
 
 import { AccountOperations } from './account.js';
-import { AuthManager } from './auth.js';
+import { ActionOperations } from './action.js';
+import { AuthManager, type RequestAuthManager, WebAuthManager } from './auth.js';
 import { ClientOperations } from './client.js';
 import { ControllerOperations } from './controller.js';
 import { DeviceOperations } from './device.js';
+import { GenericOperations } from './generic.js';
 import { InsightOperations, type SiteThreatListOptions } from './insight.js';
+import { InternalAuthManager } from './internalAuth.js';
+import { InternalRequestHandler } from './internalRequest.js';
 import { LogOperations, type LogQueryOptions } from './log.js';
 import { MaintenanceOperations } from './maintenance.js';
 import { MonitorOperations } from './monitor.js';
@@ -37,6 +42,7 @@ import { RequestHandler } from './request.js';
 import { ScheduleOperations } from './schedules.js';
 import { SecurityOperations } from './security.js';
 import { SiteOperations } from './site.js';
+import { SwitchOperations } from './switch.js';
 
 export type { LogQueryOptions, SiteThreatListOptions };
 
@@ -49,7 +55,7 @@ export type OmadaClientOptions = OmadaConnectionConfig;
 export class OmadaClient {
     private readonly http: AxiosInstance;
 
-    private readonly auth: AuthManager;
+    private readonly auth: RequestAuthManager;
 
     private readonly request: RequestHandler;
 
@@ -77,6 +83,12 @@ export class OmadaClient {
 
     private readonly scheduleOps: ScheduleOperations;
 
+    private readonly actionOps: ActionOperations;
+
+    private readonly genericOps: GenericOperations;
+
+    private readonly switchOps: SwitchOperations;
+
     private readonly omadacId: string;
 
     constructor(options: OmadaClientOptions) {
@@ -98,7 +110,10 @@ export class OmadaClient {
         this.http = axios.create(axiosOptions);
 
         // Initialize operation modules
-        this.auth = new AuthManager(this.http, options.clientId, options.clientSecret, options.omadacId);
+        this.auth =
+            options.authMode === 'web'
+                ? new WebAuthManager(this.http, options.webUsername ?? '', options.webPassword ?? '', options.omadacId)
+                : new AuthManager(this.http, options.clientId ?? '', options.clientSecret ?? '', options.omadacId);
         this.request = new RequestHandler(this.http, this.auth);
         this.siteOps = new SiteOperations(this.request, this.buildOmadaPath.bind(this), options.siteId);
         this.deviceOps = new DeviceOperations(this.request, this.siteOps, this.buildOmadaPath.bind(this));
@@ -112,6 +127,16 @@ export class OmadaClient {
         this.maintenanceOps = new MaintenanceOperations(this.request, this.siteOps, this.buildOmadaPath.bind(this));
         this.accountOps = new AccountOperations(this.request, this.buildOmadaPath.bind(this));
         this.scheduleOps = new ScheduleOperations(this.request, this.siteOps, this.buildOmadaPath.bind(this));
+        this.actionOps = new ActionOperations(this.request, this.siteOps, this.buildOmadaPath.bind(this));
+        this.genericOps = new GenericOperations(this.request, this.buildOmadaPath.bind(this));
+        this.switchOps = new SwitchOperations(this.request, this.siteOps, this.buildOmadaPath.bind(this));
+
+        if (options.webUsername && options.webPassword) {
+            const internalAuth = new InternalAuthManager(this.http, options.webUsername, options.webPassword, options.omadacId);
+            const internalReq = new InternalRequestHandler(this.http, internalAuth, options.omadacId);
+            this.networkOps.setInternalRequest(internalReq);
+            logger.info('Internal web UI API enabled for ACL and IP group management');
+        }
     }
 
     // Site operations
@@ -267,6 +292,66 @@ export class OmadaClient {
 
     public async getFirewallSetting(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
         return await this.networkOps.getFirewallSetting(siteId, customHeaders);
+    }
+
+    public async createLanNetwork(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.networkOps.createLanNetwork(data, siteId);
+    }
+
+    public async updateLanNetwork(networkId: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.networkOps.updateLanNetwork(networkId, data, siteId);
+    }
+
+    public async deleteLanNetwork(networkId: string, siteId?: string): Promise<unknown> {
+        return await this.networkOps.deleteLanNetwork(networkId, siteId);
+    }
+
+    public async createLanProfile(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.networkOps.createLanProfile(data, siteId);
+    }
+
+    public async updateLanProfile(profileId: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.networkOps.updateLanProfile(profileId, data, siteId);
+    }
+
+    public async updateFirewallSetting(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.networkOps.updateFirewallSetting(data, siteId);
+    }
+
+    public async listEvents(siteId?: string, page?: number, pageSize?: number): Promise<PaginatedResult<unknown>> {
+        return await this.networkOps.listEvents(siteId, page, pageSize);
+    }
+
+    public async listLogs(siteId?: string, page?: number, pageSize?: number): Promise<PaginatedResult<unknown>> {
+        return await this.networkOps.listLogs(siteId, page, pageSize);
+    }
+
+    public async getSwitchPorts(switchMac: string, siteId?: string): Promise<unknown[]> {
+        return await this.networkOps.getSwitchPorts(switchMac, siteId);
+    }
+
+    public async updateSwitchPort(switchMac: string, portId: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.networkOps.updateSwitchPort(switchMac, portId, data, siteId);
+    }
+
+    public async listFirewallAcls(siteId?: string): Promise<unknown> {
+        return await this.networkOps.listFirewallAcls(siteId);
+    }
+
+    public async listIpGroups(siteId?: string): Promise<unknown> {
+        return await this.networkOps.listIpGroups(siteId);
+    }
+
+    public async createFirewallAcl(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.networkOps.createFirewallAcl(data, siteId);
+    }
+
+    public async deleteFirewallAcl(aclId: string, siteId?: string): Promise<unknown> {
+        return await this.networkOps.deleteFirewallAcl(aclId, siteId);
+    }
+
+    public async listRoutes(siteId?: string): Promise<unknown[]> {
+        return await this.networkOps.listRoutes(siteId);
     }
 
     public async getSwitchDetail(switchMac: string, siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
@@ -1423,6 +1508,115 @@ export class OmadaClient {
 
     public async getPortSchedulePorts(siteId?: string, customHeaders?: CustomHeaders): Promise<unknown> {
         return await this.scheduleOps.getPortSchedulePorts(siteId, customHeaders);
+    }
+
+    // Device and client action/write operations
+    public async rebootDevice(deviceMac: string, siteId?: string): Promise<unknown> {
+        return await this.actionOps.rebootDevice(deviceMac, siteId);
+    }
+
+    public async adoptDevice(deviceMac: string, siteId?: string): Promise<unknown> {
+        return await this.actionOps.adoptDevice(deviceMac, siteId);
+    }
+
+    public async blockClient(clientMac: string, siteId?: string): Promise<unknown> {
+        return await this.actionOps.blockClient(clientMac, siteId);
+    }
+
+    public async unblockClient(clientMac: string, siteId?: string): Promise<unknown> {
+        return await this.actionOps.unblockClient(clientMac, siteId);
+    }
+
+    public async reconnectClient(clientMac: string, siteId?: string): Promise<unknown> {
+        return await this.actionOps.reconnectClient(clientMac, siteId);
+    }
+
+    public async updateClient(clientMac: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.actionOps.updateClient(clientMac, data, siteId);
+    }
+
+    public async setDeviceLed(deviceMac: string, ledSetting: number, siteId?: string): Promise<unknown> {
+        return await this.actionOps.setDeviceLed(deviceMac, ledSetting, siteId);
+    }
+
+    public async getFirmwareDetails(deviceMac: string, siteId?: string): Promise<unknown> {
+        return await this.actionOps.getFirmwareDetails(deviceMac, siteId);
+    }
+
+    public async startFirmwareUpgrade(deviceMac: string, siteId?: string): Promise<unknown> {
+        return await this.actionOps.startFirmwareUpgrade(deviceMac, siteId);
+    }
+
+    public async setGatewayWanConnect(gatewayMac: string, portId: string, action: 'connect' | 'disconnect', siteId?: string): Promise<unknown> {
+        return await this.actionOps.setGatewayWanConnect(gatewayMac, portId, action, siteId);
+    }
+
+    // Switch compatibility operations from the realtydev fork
+    public async getSwitch(switchMac: string, siteId?: string): Promise<unknown> {
+        return await this.switchOps.getSwitch(switchMac, siteId);
+    }
+
+    public async setSwitchPortProfile(switchMac: string, port: number, profileId: string, siteId?: string): Promise<unknown> {
+        return await this.switchOps.setSwitchPortProfile(switchMac, port, profileId, siteId);
+    }
+
+    public async setSwitchPortPoe(switchMac: string, port: number, poeMode: number, siteId?: string): Promise<unknown> {
+        return await this.switchOps.setSwitchPortPoe(switchMac, port, poeMode, siteId);
+    }
+
+    public async setSwitchPortName(switchMac: string, port: number, name: string, siteId?: string): Promise<unknown> {
+        return await this.switchOps.setSwitchPortName(switchMac, port, name, siteId);
+    }
+
+    public async setSwitchPortStatus(switchMac: string, port: number, status: number, siteId?: string): Promise<unknown> {
+        return await this.switchOps.setSwitchPortStatus(switchMac, port, status, siteId);
+    }
+
+    public async setSwitchPortProfileOverride(switchMac: string, port: number, profileOverrideEnable: boolean, siteId?: string): Promise<unknown> {
+        return await this.switchOps.setSwitchPortProfileOverride(switchMac, port, profileOverrideEnable, siteId);
+    }
+
+    public async batchSetSwitchPortProfile(switchMac: string, portList: number[], profileOverrideEnable: boolean, siteId?: string): Promise<unknown> {
+        return await this.switchOps.batchSetSwitchPortProfile(switchMac, portList, profileOverrideEnable, siteId);
+    }
+
+    public async batchSetSwitchPortPoe(switchMac: string, portList: number[], poeMode: number, siteId?: string): Promise<unknown> {
+        return await this.switchOps.batchSetSwitchPortPoe(switchMac, portList, poeMode, siteId);
+    }
+
+    public async batchSetSwitchPortStatus(switchMac: string, portList: number[], status: number, siteId?: string): Promise<unknown> {
+        return await this.switchOps.batchSetSwitchPortStatus(switchMac, portList, status, siteId);
+    }
+
+    public async batchSetSwitchPortName(switchMac: string, portNameList: Array<{ port: number; name: string }>, siteId?: string): Promise<unknown> {
+        return await this.switchOps.batchSetSwitchPortName(switchMac, portNameList, siteId);
+    }
+
+    public async startCableTest(switchMac: string, siteId?: string): Promise<unknown> {
+        return await this.switchOps.startCableTest(switchMac, siteId);
+    }
+
+    public async getCableTestResults(switchMac: string, siteId?: string): Promise<unknown> {
+        return await this.switchOps.getCableTestResults(switchMac, siteId);
+    }
+
+    public async getSwitchNetworks(switchMac: string, siteId?: string): Promise<unknown> {
+        return await this.switchOps.getSwitchNetworks(switchMac, siteId);
+    }
+
+    public async setSwitchNetworks(switchMac: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        return await this.switchOps.setSwitchNetworks(switchMac, data, siteId);
+    }
+
+    // Generic API compatibility wrapper
+    public async genericApiCall(
+        method: string,
+        path: string,
+        version?: string,
+        body?: unknown,
+        queryParams?: Record<string, unknown>
+    ): Promise<unknown> {
+        return await this.genericOps.genericApiCall(method, path, version, body, queryParams);
     }
 
     // Generic API call

--- a/src/omadaClient/internalAuth.ts
+++ b/src/omadaClient/internalAuth.ts
@@ -1,0 +1,105 @@
+import type { AxiosInstance } from 'axios';
+
+import { logger } from '../utils/logger.js';
+
+/**
+ * Authentication state management for the Omada internal (web UI) API.
+ * Uses cookie-based sessions with CSRF tokens instead of OAuth bearer tokens.
+ */
+export class InternalAuthManager {
+    private csrfToken?: string;
+
+    private sessionCookie?: string;
+
+    constructor(
+        private readonly http: AxiosInstance,
+        private readonly username: string,
+        private readonly password: string,
+        private readonly omadacId: string
+    ) {}
+
+    /**
+     * Get the current CSRF token, logging in if necessary.
+     */
+    public async getCsrfToken(): Promise<string> {
+        if (!this.csrfToken || !this.sessionCookie) {
+            await this.login();
+        }
+        return this.csrfToken ?? '';
+    }
+
+    /**
+     * Get the current session cookie.
+     */
+    public async getSessionCookie(): Promise<string> {
+        if (!this.csrfToken || !this.sessionCookie) {
+            await this.login();
+        }
+        return this.sessionCookie ?? '';
+    }
+
+    /**
+     * Clear the current session, forcing re-login on next request.
+     */
+    public clearSession(): void {
+        this.csrfToken = undefined;
+        this.sessionCookie = undefined;
+    }
+
+    /**
+     * Check if web credentials are configured.
+     */
+    public isConfigured(): boolean {
+        return Boolean(this.username && this.password);
+    }
+
+    /**
+     * Log in to the internal web UI API and extract session cookie + CSRF token.
+     */
+    private async login(): Promise<void> {
+        const loginPath = `/${encodeURIComponent(this.omadacId)}/api/v2/login`;
+
+        try {
+            const response = await this.http.post(loginPath, { username: this.username, password: this.password }, { withCredentials: true });
+
+            const data = response.data as { errorCode?: number; msg?: string; result?: { token?: string } };
+
+            if (data.errorCode !== 0) {
+                logger.error('Internal API login error', {
+                    errorCode: data.errorCode,
+                    message: data.msg,
+                });
+                throw new Error(data.msg ?? 'Internal API login failed');
+            }
+
+            // Extract CSRF token from response body
+            const token = data.result?.token;
+            if (!token) {
+                throw new Error('Internal API login succeeded but no CSRF token returned');
+            }
+            this.csrfToken = token;
+
+            // Extract session cookie from Set-Cookie header
+            const setCookieHeader = response.headers['set-cookie'];
+            if (setCookieHeader) {
+                // Collect all cookie name=value pairs
+                const cookies = (Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader])
+                    .map((c: string) => c.split(';')[0].trim())
+                    .filter(Boolean);
+                this.sessionCookie = cookies.join('; ');
+            }
+
+            if (!this.sessionCookie) {
+                logger.warn('Internal API login succeeded but no session cookie received; requests may fail');
+            }
+
+            logger.info('Internal API login successful');
+        } catch (error) {
+            logger.error('Internal API login failed', {
+                baseUrl: this.http.defaults.baseURL,
+                error: error instanceof Error ? error.message : String(error),
+            });
+            throw error;
+        }
+    }
+}

--- a/src/omadaClient/internalRequest.ts
+++ b/src/omadaClient/internalRequest.ts
@@ -1,0 +1,209 @@
+import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosRequestHeaders } from 'axios';
+
+import type { OmadaApiResponse } from '../types/index.js';
+import { logger } from '../utils/logger.js';
+
+import type { InternalAuthManager } from './internalAuth.js';
+
+/**
+ * HTTP request handler for Omada internal (web UI) API calls.
+ * Uses cookie + Csrf-Token header instead of bearer token authentication.
+ * The internal API base path is /{omadacId}/api/v2 (not /openapi/v1/{omadacId}).
+ */
+export class InternalRequestHandler {
+    constructor(
+        private readonly http: AxiosInstance,
+        private readonly auth: InternalAuthManager,
+        private readonly omadacId: string
+    ) {}
+
+    /**
+     * Make a GET request to the internal API.
+     */
+    public async get<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+        return await this.request<T>({ method: 'GET', url: this.buildInternalPath(path), params });
+    }
+
+    /**
+     * Make a POST request to the internal API.
+     */
+    public async post<T>(path: string, data: unknown, params?: Record<string, unknown>): Promise<T> {
+        return await this.request<T>({ method: 'POST', url: this.buildInternalPath(path), data, params });
+    }
+
+    /**
+     * Make a DELETE request to the internal API.
+     */
+    public async delete<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+        return await this.request<T>({ method: 'DELETE', url: this.buildInternalPath(path), params });
+    }
+
+    /**
+     * Ensure an internal API response indicates success.
+     * @throws {Error} If the response contains an error code
+     */
+    public ensureSuccess<T>(response: OmadaApiResponse<T>): T {
+        if (response.errorCode !== 0) {
+            logger.error('Internal API error', {
+                errorCode: response.errorCode,
+                message: response.msg,
+            });
+            throw new Error(response.msg ?? 'Internal API request failed');
+        }
+
+        return (response.result ?? ({} as T)) as T;
+    }
+
+    /**
+     * Build the internal API path: /{omadacId}/api/v2{relativePath}
+     */
+    private buildInternalPath(relativePath: string): string {
+        const normalized = relativePath.startsWith('/') ? relativePath : `/${relativePath}`;
+        return `/${encodeURIComponent(this.omadacId)}/api/v2${normalized}`;
+    }
+
+    /**
+     * Make an authenticated request to the internal API with retry on session expiry.
+     */
+    private async request<T>(config: AxiosRequestConfig, retry = true): Promise<T> {
+        const csrfToken = await this.auth.getCsrfToken();
+        const sessionCookie = await this.auth.getSessionCookie();
+
+        const requestConfig: AxiosRequestConfig = {
+            ...config,
+            headers: {
+                ...(config.headers ?? {}),
+                'Csrf-Token': csrfToken,
+                Cookie: sessionCookie,
+            },
+            withCredentials: true,
+        };
+
+        const method = (requestConfig.method ?? 'GET').toUpperCase();
+        const url = requestConfig.url ?? 'unknown-url';
+        logger.info('Internal API request', {
+            method,
+            url,
+            params: requestConfig.params,
+        });
+
+        logger.debug('Internal API request details', {
+            method,
+            url,
+            headers: this.sanitizeHeaders(requestConfig.headers as AxiosRequestHeaders | undefined),
+            params: requestConfig.params ?? null,
+            data: this.sanitizePayload(requestConfig.data),
+        });
+
+        try {
+            const response = await this.http.request<T>(requestConfig);
+            logger.info('Internal API response', {
+                method,
+                url,
+                status: response.status,
+            });
+
+            logger.debug('Internal API response payload', {
+                method,
+                url,
+                status: response.status,
+                data: this.sanitizePayload(response.data),
+            });
+
+            // Check for session expiry in response
+            const errorCode = (response.data as { errorCode?: number } | undefined)?.errorCode;
+            const errorMsg = (response.data as { msg?: string } | undefined)?.msg;
+
+            if (retry && this.isSessionExpired(errorCode, errorMsg)) {
+                logger.warn('Internal API session expired, re-logging in', { method, url, errorCode });
+                this.auth.clearSession();
+                return this.request<T>(config, false);
+            }
+
+            return response.data;
+        } catch (error) {
+            logger.error('Internal API request failed', {
+                method,
+                url,
+                message: error instanceof Error ? error.message : String(error),
+            });
+
+            if (!retry || !axios.isAxiosError(error)) {
+                throw error;
+            }
+
+            const status = error.response?.status;
+            if (status === 401 || status === 403) {
+                this.auth.clearSession();
+                return this.request<T>(config, false);
+            }
+
+            throw error;
+        }
+    }
+
+    /**
+     * Check if the error indicates an expired or invalid session.
+     */
+    private isSessionExpired(errorCode?: number, message?: string): boolean {
+        // Common internal API auth error codes
+        if (errorCode === -44106 || errorCode === -44112 || errorCode === -44113) {
+            return true;
+        }
+        if (message) {
+            const lower = message.toLowerCase();
+            return lower.includes('token expired') || lower.includes('session expired') || lower.includes('not logged in');
+        }
+        return false;
+    }
+
+    /**
+     * Sanitize HTTP headers for logging, masking sensitive values.
+     */
+    private sanitizeHeaders(headers: AxiosRequestHeaders | undefined): Record<string, unknown> | undefined {
+        if (!headers) {
+            return undefined;
+        }
+
+        const sanitized: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(headers)) {
+            sanitized[key] = this.isSensitiveKey(key) ? '********' : value;
+        }
+
+        return sanitized;
+    }
+
+    /**
+     * Sanitize a payload for logging, masking sensitive values.
+     */
+    private sanitizePayload(payload: unknown): unknown {
+        if (!payload || typeof payload !== 'object') {
+            return payload;
+        }
+
+        if (Array.isArray(payload)) {
+            return payload.map((item) => this.sanitizePayload(item));
+        }
+
+        const sanitized: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(payload)) {
+            sanitized[key] = this.isSensitiveKey(key) ? '********' : this.sanitizePayload(value);
+        }
+
+        return sanitized;
+    }
+
+    /**
+     * Check if a key name indicates sensitive data.
+     */
+    private isSensitiveKey(key: string): boolean {
+        const normalized = key.toLowerCase();
+        return (
+            normalized.includes('cookie') ||
+            normalized.includes('csrf') ||
+            normalized.includes('token') ||
+            normalized.includes('password') ||
+            normalized.includes('secret')
+        );
+    }
+}

--- a/src/omadaClient/network.ts
+++ b/src/omadaClient/network.ts
@@ -1,5 +1,7 @@
 import type { CustomHeaders, OmadaApiResponse, PaginatedResult } from '../types/index.js';
+import { logger } from '../utils/logger.js';
 
+import type { InternalRequestHandler } from './internalRequest.js';
 import type { RequestHandler } from './request.js';
 import type { SiteOperations } from './site.js';
 
@@ -8,11 +10,25 @@ import type { SiteOperations } from './site.js';
  * Covers internet, LAN, WLAN, firewall, and port forwarding configurations.
  */
 export class NetworkOperations {
+    private internalRequest?: InternalRequestHandler;
+
     constructor(
         private readonly request: RequestHandler,
         private readonly site: SiteOperations,
         private readonly buildPath: (path: string, version?: string) => string
     ) {}
+
+    /**
+     * Set the internal request handler for web UI API access.
+     * When configured, firewall ACL/IP group operations can use Fusion-compatible endpoints.
+     */
+    public setInternalRequest(internalRequest: InternalRequestHandler): void {
+        this.internalRequest = internalRequest;
+    }
+
+    private get hasInternalApi(): boolean {
+        return this.internalRequest !== undefined;
+    }
 
     /**
      * Get internet configuration info for a site.
@@ -1583,5 +1599,199 @@ export class NetworkOperations {
         const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/multicast-rate-limit`);
         const response = await this.request.get<OmadaApiResponse<unknown>>(path, undefined, customHeaders);
         return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Create a new LAN network (v2 API).
+     */
+    public async createLanNetwork(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/lan-networks`, 'v2');
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, data);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Update an existing LAN network (v2 API).
+     */
+    public async updateLanNetwork(networkId: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/lan-networks/${encodeURIComponent(networkId)}`, 'v2');
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, data);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Delete a LAN network (v2 API).
+     */
+    public async deleteLanNetwork(networkId: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/lan-networks/${encodeURIComponent(networkId)}`, 'v2');
+        const response = await this.request.delete<OmadaApiResponse<unknown>>(path);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Create a new LAN profile (v1 API).
+     */
+    public async createLanProfile(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/lan-profiles`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, data);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Update an existing LAN profile (v1 API).
+     */
+    public async updateLanProfile(profileId: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/lan-profiles/${encodeURIComponent(profileId)}`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, data);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Update firewall settings for a site (v1 API).
+     */
+    public async updateFirewallSetting(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/firewall`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, data);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get paginated events for a site (v1 API).
+     */
+    public async listEvents(siteId?: string, page = 1, pageSize = 10): Promise<PaginatedResult<unknown>> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/events`);
+        const response = await this.request.get<OmadaApiResponse<PaginatedResult<unknown>>>(path, {
+            page,
+            pageSize,
+        });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get paginated logs for a site (v1 API).
+     */
+    public async listLogs(siteId?: string, page = 1, pageSize = 10): Promise<PaginatedResult<unknown>> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/logs`);
+        const response = await this.request.get<OmadaApiResponse<PaginatedResult<unknown>>>(path, {
+            page,
+            pageSize,
+        });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get switch ports for a specific switch (v1 API, paginated).
+     */
+    public async getSwitchPorts(switchMac: string, siteId?: string): Promise<unknown[]> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/ports`);
+        return await this.request.fetchPaginated<unknown>(path);
+    }
+
+    /**
+     * Update a switch port configuration (v1 API).
+     */
+    public async updateSwitchPort(switchMac: string, portId: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(
+            `/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/ports/${encodeURIComponent(portId)}`
+        );
+        const response = await this.request.request<OmadaApiResponse<unknown>>({ method: 'PATCH', url: path, data });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * List firewall ACL rules for a site (v1 API).
+     */
+    public async listFirewallAcls(siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+
+        if (this.hasInternalApi) {
+            logger.info('Using internal API for listFirewallAcls');
+            const path = `/sites/${encodeURIComponent(resolvedSiteId)}/setting/firewall/acls`;
+            const response = await this.internalRequest!.get<OmadaApiResponse<unknown>>(path, {
+                type: 0,
+                currentPage: 1,
+                currentPageSize: 100,
+            });
+            return this.internalRequest!.ensureSuccess(response);
+        }
+
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/setting/firewall/acls`);
+        return await this.request.fetchPaginated<unknown>(path);
+    }
+
+    /**
+     * Create a firewall ACL rule (v1 API).
+     */
+    public async createFirewallAcl(data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+
+        if (this.hasInternalApi) {
+            logger.info('Using internal API for createFirewallAcl');
+            const path = `/sites/${encodeURIComponent(resolvedSiteId)}/setting/firewall/acls`;
+            const response = await this.internalRequest!.post<OmadaApiResponse<unknown>>(path, data);
+            return this.internalRequest!.ensureSuccess(response);
+        }
+
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/setting/firewall/acls`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, data);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Delete a firewall ACL rule (v1 API).
+     */
+    public async deleteFirewallAcl(aclId: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+
+        if (this.hasInternalApi) {
+            logger.info('Using internal API for deleteFirewallAcl');
+            const path = `/sites/${encodeURIComponent(resolvedSiteId)}/setting/firewall/acls/${encodeURIComponent(aclId)}`;
+            const response = await this.internalRequest!.delete<OmadaApiResponse<unknown>>(path);
+            return this.internalRequest!.ensureSuccess(response);
+        }
+
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/setting/firewall/acls/${encodeURIComponent(aclId)}`);
+        const response = await this.request.delete<OmadaApiResponse<unknown>>(path);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * List IP/Port groups for a site (internal API only).
+     * These groups can be used as source/destination in firewall ACL rules.
+     */
+    public async listIpGroups(siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+
+        if (!this.hasInternalApi) {
+            throw new Error(
+                'listIpGroups requires the internal web UI API. Set OMADA_WEB_USERNAME and OMADA_WEB_PASSWORD environment variables to enable it.'
+            );
+        }
+
+        const path = `/sites/${encodeURIComponent(resolvedSiteId)}/setting/profiles/groups`;
+        const response = await this.internalRequest!.get<OmadaApiResponse<unknown>>(path, {
+            currentPage: 1,
+            currentPageSize: 100,
+        });
+        return this.internalRequest!.ensureSuccess(response);
+    }
+
+    /**
+     * List static routes for a site (v1 API).
+     */
+    public async listRoutes(siteId?: string): Promise<unknown[]> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/setting/routes`);
+        return await this.request.fetchPaginated<unknown>(path);
     }
 }

--- a/src/omadaClient/request.ts
+++ b/src/omadaClient/request.ts
@@ -3,7 +3,7 @@ import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosRequestHe
 import type { CustomHeaders, OmadaApiResponse, PaginatedResult } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 
-import type { AuthManager } from './auth.js';
+import type { RequestAuthManager } from './auth.js';
 
 const DEFAULT_PAGE_SIZE = 200;
 
@@ -13,7 +13,7 @@ const DEFAULT_PAGE_SIZE = 200;
 export class RequestHandler {
     constructor(
         private readonly http: AxiosInstance,
-        private readonly auth: AuthManager
+        private readonly auth: RequestAuthManager
     ) {}
 
     /**
@@ -31,17 +31,38 @@ export class RequestHandler {
     }
 
     /**
+     * Make a POST request to the Omada API.
+     */
+    public async post<T>(path: string, data: unknown, params?: Record<string, unknown>): Promise<T> {
+        return await this.request<T>({ method: 'POST', url: path, data, params });
+    }
+
+    /**
+     * Make a PUT request to the Omada API.
+     */
+    public async put<T>(path: string, data: unknown, params?: Record<string, unknown>): Promise<T> {
+        return await this.request<T>({ method: 'PUT', url: path, data, params });
+    }
+
+    /**
+     * Make a DELETE request to the Omada API.
+     */
+    public async delete<T>(path: string, params?: Record<string, unknown>): Promise<T> {
+        return await this.request<T>({ method: 'DELETE', url: path, params });
+    }
+
+    /**
      * Make an arbitrary HTTP request to the Omada API.
      */
     public async request<T>(config: AxiosRequestConfig, retry = true, customHeaders?: CustomHeaders): Promise<T> {
-        const accessToken = await this.auth.getAccessToken();
+        const authHeaders = await this.auth.getAuthHeaders();
 
         const requestConfig: AxiosRequestConfig = {
             ...config,
             headers: {
                 ...(config.headers ?? {}),
                 ...(customHeaders ?? {}),
-                Authorization: `AccessToken=${accessToken}`,
+                ...authHeaders,
             },
         };
 
@@ -249,6 +270,8 @@ export class RequestHandler {
         const normalized = key.toLowerCase();
         return (
             normalized.includes('authorization') ||
+            normalized.includes('cookie') ||
+            normalized.includes('csrf') ||
             normalized.includes('token') ||
             normalized.includes('secret') ||
             normalized.includes('password') ||

--- a/src/omadaClient/switch.ts
+++ b/src/omadaClient/switch.ts
@@ -1,0 +1,165 @@
+import type { OmadaApiResponse } from '../types/index.js';
+
+import type { RequestHandler } from './request.js';
+import type { SiteOperations } from './site.js';
+
+/**
+ * Switch port and cable test operations for the Omada API.
+ * Covers single-port config, batch operations, cable tests, and switch networks.
+ */
+export class SwitchOperations {
+    constructor(
+        private readonly request: RequestHandler,
+        private readonly site: SiteOperations,
+        private readonly buildPath: (path: string, version?: string) => string
+    ) {}
+
+    /**
+     * Get full switch info including portList array (v1 API).
+     */
+    public async getSwitch(switchMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Set a LAN profile on a single switch port (v1 API).
+     */
+    public async setSwitchPortProfile(switchMac: string, port: number, profileId: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/ports/${port}/profile`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { profileId });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Set PoE mode on a single switch port (v1 API).
+     * @param poeMode - 1=on(802.3at/af), 0=off
+     */
+    public async setSwitchPortPoe(switchMac: string, port: number, poeMode: number, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/ports/${port}/poe-mode`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { poeMode });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Set the name of a single switch port (v1 API).
+     * @param name - Port name, 1-128 characters
+     */
+    public async setSwitchPortName(switchMac: string, port: number, name: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/ports/${port}/name`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { name });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Enable or disable a single switch port (v1 API).
+     * @param status - 0=off, 1=on
+     */
+    public async setSwitchPortStatus(switchMac: string, port: number, status: number, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/ports/${port}/status`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { status });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Enable or disable profile override on a single switch port (v1 API).
+     */
+    public async setSwitchPortProfileOverride(switchMac: string, port: number, profileOverrideEnable: boolean, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(
+            `/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/ports/${port}/profile-override`
+        );
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { profileOverrideEnable });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Batch set profile override on multiple switch ports (v1 API).
+     */
+    public async batchSetSwitchPortProfile(switchMac: string, portList: number[], profileOverrideEnable: boolean, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(
+            `/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/multi-ports/profile-override`
+        );
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { portList, profileOverrideEnable });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Batch set PoE mode on multiple switch ports (v1 API).
+     * @param poeMode - 1=on(802.3at/af), 0=off
+     */
+    public async batchSetSwitchPortPoe(switchMac: string, portList: number[], poeMode: number, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/multi-ports/poe-mode`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { portList, poeMode });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Batch enable or disable multiple switch ports (v1 API).
+     * @param status - 0=off, 1=on
+     */
+    public async batchSetSwitchPortStatus(switchMac: string, portList: number[], status: number, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/multi-ports/status`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { portList, status });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Batch set names on multiple switch ports (v1 API).
+     */
+    public async batchSetSwitchPortName(switchMac: string, portNameList: Array<{ port: number; name: string }>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/multi-ports/name`);
+        const response = await this.request.put<OmadaApiResponse<unknown>>(path, { portNameList });
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Start a cable test on a switch (v1 API).
+     */
+    public async startCableTest(switchMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/cable-test/switches/${encodeURIComponent(switchMac)}/start`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, {});
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get cable test results for a switch (v1 API).
+     */
+    public async getCableTestResults(switchMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/cable-test/switches/${encodeURIComponent(switchMac)}/full-results`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Get switch networks / VLAN trunking config (v1 API).
+     */
+    public async getSwitchNetworks(switchMac: string, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/networks`);
+        const response = await this.request.get<OmadaApiResponse<unknown>>(path);
+        return this.request.ensureSuccess(response);
+    }
+
+    /**
+     * Set switch networks / VLAN trunking config (v1 API).
+     */
+    public async setSwitchNetworks(switchMac: string, data: Record<string, unknown>, siteId?: string): Promise<unknown> {
+        const resolvedSiteId = this.site.resolveSiteId(siteId);
+        const path = this.buildPath(`/sites/${encodeURIComponent(resolvedSiteId)}/switches/${encodeURIComponent(switchMac)}/networks`);
+        const response = await this.request.post<OmadaApiResponse<unknown>>(path, data);
+        return this.request.ensureSuccess(response);
+    }
+}

--- a/src/server/stdio.ts
+++ b/src/server/stdio.ts
@@ -1,13 +1,13 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-import type { ToolCategory, ToolPermission } from '../config.js';
+import type { ToolCategory, ToolFilter, ToolPermission } from '../config.js';
 import type { OmadaClient } from '../omadaClient/index.js';
 import { registerAllTools } from '../tools/index.js';
 import { logger } from '../utils/logger.js';
 
 import { createServer } from './common.js';
 
-export async function startStdioServer(client: OmadaClient, activeCategories?: Map<ToolCategory, Set<ToolPermission>>): Promise<void> {
+export async function startStdioServer(client: OmadaClient, activeCategories?: ToolFilter | Map<ToolCategory, Set<ToolPermission>>): Promise<void> {
     logger.info('Starting stdio server');
     const server = createServer();
     registerAllTools(server, client, activeCategories);

--- a/src/tools/adoptDevice.ts
+++ b/src/tools/adoptDevice.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const adoptDeviceSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    deviceMac: z.string().min(1, 'deviceMac is required'),
+});
+
+export function registerAdoptDeviceTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'adoptDevice',
+        {
+            description: 'Adopt a pending device by its MAC address into the site.',
+            inputSchema: adoptDeviceSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('adoptDevice', async ({ deviceMac, siteId }) => toToolResult(await client.adoptDevice(deviceMac, siteId)))
+    );
+}

--- a/src/tools/batchSetSwitchPortName.ts
+++ b/src/tools/batchSetSwitchPortName.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const batchSetSwitchPortNameSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    portNameList: z
+        .array(
+            z.object({
+                port: z.number().int().min(1),
+                name: z.string().min(1).max(128),
+            })
+        )
+        .min(1, 'portNameList must contain at least one entry'),
+});
+
+export function registerBatchSetSwitchPortNameTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'batchSetSwitchPortName',
+        {
+            description: 'Batch set names on multiple switch ports. Each entry specifies a port number and name (1-128 chars).',
+            inputSchema: batchSetSwitchPortNameSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('batchSetSwitchPortName', async ({ switchMac, portNameList, siteId }) =>
+            toToolResult(await client.batchSetSwitchPortName(switchMac, portNameList, siteId))
+        )
+    );
+}

--- a/src/tools/batchSetSwitchPortPoe.ts
+++ b/src/tools/batchSetSwitchPortPoe.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const batchSetSwitchPortPoeSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    portList: z.array(z.number().int().min(1)).min(1, 'portList must contain at least one port'),
+    poeMode: z.number().int().min(0).max(1).describe('1=on (802.3at/af), 0=off'),
+});
+
+export function registerBatchSetSwitchPortPoeTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'batchSetSwitchPortPoe',
+        {
+            description: 'Batch enable or disable PoE on multiple switch ports. 1=on (802.3at/af), 0=off.',
+            inputSchema: batchSetSwitchPortPoeSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('batchSetSwitchPortPoe', async ({ switchMac, portList, poeMode, siteId }) =>
+            toToolResult(await client.batchSetSwitchPortPoe(switchMac, portList, poeMode, siteId))
+        )
+    );
+}

--- a/src/tools/batchSetSwitchPortProfile.ts
+++ b/src/tools/batchSetSwitchPortProfile.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const batchSetSwitchPortProfileSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    portList: z.array(z.number().int().min(1)).min(1, 'portList must contain at least one port'),
+    profileOverrideEnable: z.boolean().describe('Enable or disable profile override on all specified ports'),
+});
+
+export function registerBatchSetSwitchPortProfileTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'batchSetSwitchPortProfile',
+        {
+            description: 'Batch enable or disable profile override on multiple switch ports.',
+            inputSchema: batchSetSwitchPortProfileSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('batchSetSwitchPortProfile', async ({ switchMac, portList, profileOverrideEnable, siteId }) =>
+            toToolResult(await client.batchSetSwitchPortProfile(switchMac, portList, profileOverrideEnable, siteId))
+        )
+    );
+}

--- a/src/tools/batchSetSwitchPortStatus.ts
+++ b/src/tools/batchSetSwitchPortStatus.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const batchSetSwitchPortStatusSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    portList: z.array(z.number().int().min(1)).min(1, 'portList must contain at least one port'),
+    status: z.number().int().min(0).max(1).describe('0=off, 1=on'),
+});
+
+export function registerBatchSetSwitchPortStatusTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'batchSetSwitchPortStatus',
+        {
+            description: 'Batch enable or disable multiple switch ports. 0=off, 1=on.',
+            inputSchema: batchSetSwitchPortStatusSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('batchSetSwitchPortStatus', async ({ switchMac, portList, status, siteId }) =>
+            toToolResult(await client.batchSetSwitchPortStatus(switchMac, portList, status, siteId))
+        )
+    );
+}

--- a/src/tools/blockClient.ts
+++ b/src/tools/blockClient.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const blockClientSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    clientMac: z.string().min(1, 'clientMac is required'),
+});
+
+export function registerBlockClientTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'blockClient',
+        {
+            description: 'Block a client device by its MAC address, preventing it from accessing the network.',
+            inputSchema: blockClientSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('blockClient', async ({ clientMac, siteId }) => toToolResult(await client.blockClient(clientMac, siteId)))
+    );
+}

--- a/src/tools/createFirewallAcl.ts
+++ b/src/tools/createFirewallAcl.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const createFirewallAclSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    rule: z
+        .record(z.unknown())
+        .describe('Firewall ACL rule object (fields vary by controller version; use listFirewallAcls to see existing rule shapes)'),
+});
+
+export function registerCreateFirewallAclTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'createFirewallAcl',
+        {
+            description:
+                'Create a firewall ACL rule for inter-VLAN isolation or traffic control. ' +
+                'Use listFirewallAcls first to see the expected rule shape.',
+            inputSchema: createFirewallAclSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('createFirewallAcl', async ({ siteId, rule }) => toToolResult(await client.createFirewallAcl(rule, siteId)))
+    );
+}

--- a/src/tools/createLanNetwork.ts
+++ b/src/tools/createLanNetwork.ts
@@ -1,0 +1,36 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const dhcpSettingsSchema = z.object({
+    enable: z.boolean().describe('Whether DHCP is enabled'),
+    ipRangeStart: z.string().min(1).describe('DHCP range start IP (e.g. "192.168.10.100")'),
+    ipRangeEnd: z.string().min(1).describe('DHCP range end IP (e.g. "192.168.10.200")'),
+    leaseTime: z.number().int().describe('DHCP lease time in seconds'),
+});
+
+const createLanNetworkSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    name: z.string().min(1, 'Network name is required'),
+    vlan: z.number().int().describe('VLAN ID'),
+    gatewaySubnet: z.string().min(1).describe('Gateway and subnet in CIDR notation (e.g. "192.168.10.1/24")'),
+    purpose: z.number().int().describe('Network purpose (1 = interface)'),
+    igmpSnoopEnable: z.boolean().describe('Whether IGMP snooping is enabled'),
+    dhcpSettings: dhcpSettingsSchema.describe('DHCP server settings'),
+});
+
+export function registerCreateLanNetworkTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'createLanNetwork',
+        {
+            description: 'Create a new LAN network with VLAN, gateway/subnet, and DHCP settings.',
+            inputSchema: createLanNetworkSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('createLanNetwork', async ({ siteId, ...data }) => toToolResult(await client.createLanNetwork(data, siteId)))
+    );
+}

--- a/src/tools/createLanProfile.ts
+++ b/src/tools/createLanProfile.ts
@@ -1,0 +1,31 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const createLanProfileSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    name: z.string().min(1, 'Profile name is required'),
+    nativeNetworkId: z.string().min(1).describe('Native (untagged) network ID'),
+    tagNetworkIds: z.array(z.string().min(1)).describe('Tagged network IDs'),
+    poe: z.boolean().describe('Whether PoE is enabled'),
+    spanningTreeEnable: z.boolean().describe('Whether Spanning Tree Protocol is enabled'),
+    loopbackDetectEnable: z.boolean().describe('Whether loopback detection is enabled'),
+    portIsolationEnable: z.boolean().describe('Whether port isolation is enabled'),
+    lldpMedEnable: z.boolean().describe('Whether LLDP-MED is enabled'),
+});
+
+export function registerCreateLanProfileTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'createLanProfile',
+        {
+            description: 'Create a new LAN profile with native/tagged network assignments and port settings.',
+            inputSchema: createLanProfileSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('createLanProfile', async ({ siteId, ...data }) => toToolResult(await client.createLanProfile(data, siteId)))
+    );
+}

--- a/src/tools/deleteFirewallAcl.ts
+++ b/src/tools/deleteFirewallAcl.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const deleteFirewallAclSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    aclId: z.string().min(1, 'aclId is required'),
+});
+
+export function registerDeleteFirewallAclTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'deleteFirewallAcl',
+        {
+            description: 'Delete a firewall ACL rule by its ID.',
+            inputSchema: deleteFirewallAclSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('deleteFirewallAcl', async ({ aclId, siteId }) => toToolResult(await client.deleteFirewallAcl(aclId, siteId)))
+    );
+}

--- a/src/tools/deleteLanNetwork.ts
+++ b/src/tools/deleteLanNetwork.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const deleteLanNetworkSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    networkId: z.string().min(1, 'networkId is required'),
+});
+
+export function registerDeleteLanNetworkTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'deleteLanNetwork',
+        {
+            description: 'Delete a LAN network by its network ID.',
+            inputSchema: deleteLanNetworkSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('deleteLanNetwork', async ({ siteId, networkId }) => toToolResult(await client.deleteLanNetwork(networkId, siteId)))
+    );
+}

--- a/src/tools/genericApiCall.ts
+++ b/src/tools/genericApiCall.ts
@@ -1,0 +1,32 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const genericApiCallSchema = z.object({
+    method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+    path: z.string().min(1, 'path is required (e.g. /sites/{siteId}/setting/firewall/acls)'),
+    version: z.enum(['v1', 'v2']).optional().default('v1'),
+    body: z.record(z.unknown()).optional(),
+    queryParams: z.record(z.unknown()).optional(),
+});
+
+export function registerGenericApiCallTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'genericApiCall',
+        {
+            description:
+                'Execute an arbitrary Omada API call. Use this for any endpoint not covered by other tools. ' +
+                'Path is relative (e.g. "/sites/{siteId}/setting/firewall/acls"). ' +
+                'The omadacId prefix is added automatically.',
+            inputSchema: genericApiCallSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('genericApiCall', async ({ method, path, version, body, queryParams }) =>
+            toToolResult(await client.genericApiCall(method, path, version, body, queryParams))
+        )
+    );
+}

--- a/src/tools/getCableTestResults.ts
+++ b/src/tools/getCableTestResults.ts
@@ -1,0 +1,21 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const getCableTestResultsSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+});
+
+export function registerGetCableTestResultsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getCableTestResults',
+        {
+            description: 'Get cable test results for a switch. Run startCableTest first.',
+            inputSchema: getCableTestResultsSchema.shape,
+        },
+        wrapToolHandler('getCableTestResults', async ({ switchMac, siteId }) => toToolResult(await client.getCableTestResults(switchMac, siteId)))
+    );
+}

--- a/src/tools/getFirmwareDetails.ts
+++ b/src/tools/getFirmwareDetails.ts
@@ -1,0 +1,21 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const getFirmwareDetailsSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    deviceMac: z.string().min(1, 'deviceMac is required'),
+});
+
+export function registerGetFirmwareDetailsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getFirmwareDetails',
+        {
+            description: 'Get firmware information for a device including current version and available updates.',
+            inputSchema: getFirmwareDetailsSchema.shape,
+        },
+        wrapToolHandler('getFirmwareDetails', async ({ deviceMac, siteId }) => toToolResult(await client.getFirmwareDetails(deviceMac, siteId)))
+    );
+}

--- a/src/tools/getSwitch.ts
+++ b/src/tools/getSwitch.ts
@@ -1,0 +1,21 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const getSwitchSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+});
+
+export function registerGetSwitchTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getSwitch',
+        {
+            description: 'Get full switch info including portList array by MAC address.',
+            inputSchema: getSwitchSchema.shape,
+        },
+        wrapToolHandler('getSwitch', async ({ switchMac, siteId }) => toToolResult(await client.getSwitch(switchMac, siteId)))
+    );
+}

--- a/src/tools/getSwitchNetworks.ts
+++ b/src/tools/getSwitchNetworks.ts
@@ -1,0 +1,21 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const getSwitchNetworksSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+});
+
+export function registerGetSwitchNetworksTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getSwitchNetworks',
+        {
+            description: 'Get switch networks / VLAN trunking configuration for a switch.',
+            inputSchema: getSwitchNetworksSchema.shape,
+        },
+        wrapToolHandler('getSwitchNetworks', async ({ switchMac, siteId }) => toToolResult(await client.getSwitchNetworks(switchMac, siteId)))
+    );
+}

--- a/src/tools/getSwitchPorts.ts
+++ b/src/tools/getSwitchPorts.ts
@@ -1,0 +1,21 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const getSwitchPortsSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+});
+
+export function registerGetSwitchPortsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'getSwitchPorts',
+        {
+            description: 'Get all ports for a switch by its MAC address, including status, profile, PoE, link speed, and STP state.',
+            inputSchema: getSwitchPortsSchema.shape,
+        },
+        wrapToolHandler('getSwitchPorts', async ({ switchMac, siteId }) => toToolResult(await client.getSwitchPorts(switchMac, siteId)))
+    );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import type { ToolCategory, ToolPermission } from '../config.js';
+import type { ToolCategory, ToolFilter, ToolPermission } from '../config.js';
 import type { OmadaClient } from '../omadaClient/index.js';
 import { logger } from '../utils/logger.js';
 import { registerAdoptDeviceTool } from './adoptDevice.js';
@@ -381,6 +381,69 @@ interface ToolEntry {
     category: ToolCategory;
     permission: ToolPermission;
 }
+
+const DEFAULT_TOOL_FNS = new Set<(server: McpServer, client: OmadaClient) => void>([
+    registerAdoptDeviceTool,
+    registerBatchSetSwitchPortNameTool,
+    registerBatchSetSwitchPortPoeTool,
+    registerBatchSetSwitchPortProfileTool,
+    registerBatchSetSwitchPortStatusTool,
+    registerBlockClientTool,
+    registerCreateFirewallAclTool,
+    registerCreateLanNetworkTool,
+    registerCreateLanProfileTool,
+    registerDeleteFirewallAclTool,
+    registerDeleteLanNetworkTool,
+    registerGenericApiCallTool,
+    registerGetCableTestResultsTool,
+    registerGetClientTool,
+    registerGetDeviceTool,
+    registerGetFirewallSettingTool,
+    registerGetFirmwareDetailsTool,
+    registerGetInternetInfoTool,
+    registerGetLanNetworkListTool,
+    registerGetLanProfileListTool,
+    registerGetPortForwardingStatusTool,
+    registerGetSsidDetailTool,
+    registerGetSsidListTool,
+    registerGetSwitchTool,
+    registerGetSwitchNetworksTool,
+    registerGetSwitchPortsTool,
+    registerGetSwitchStackDetailTool,
+    registerGetThreatListTool,
+    registerGetWlanGroupListTool,
+    registerListClientsTool,
+    registerListClientsActivityTool,
+    registerListClientsPastConnectionsTool,
+    registerListDevicesTool,
+    registerListDevicesStatsTool,
+    registerListEventsTool,
+    registerListFirewallAclsTool,
+    registerListIpGroupsTool,
+    registerListLogsTool,
+    registerListMostActiveClientsTool,
+    registerListRoutesTool,
+    registerListSitesTool,
+    registerRebootDeviceTool,
+    registerReconnectClientTool,
+    registerSearchDevicesTool,
+    registerSetDeviceLedTool,
+    registerSetGatewayWanConnectTool,
+    registerSetSwitchNetworksTool,
+    registerSetSwitchPortNameTool,
+    registerSetSwitchPortPoeTool,
+    registerSetSwitchPortProfileTool,
+    registerSetSwitchPortProfileOverrideTool,
+    registerSetSwitchPortStatusTool,
+    registerStartCableTestTool,
+    registerStartFirmwareUpgradeTool,
+    registerUnblockClientTool,
+    registerUpdateClientTool,
+    registerUpdateFirewallSettingTool,
+    registerUpdateLanNetworkTool,
+    registerUpdateLanProfileTool,
+    registerUpdateSwitchPortTool,
+]);
 
 const TOOL_REGISTRY: ToolEntry[] = [
     // --- Sites ---
@@ -818,19 +881,33 @@ const TOOL_REGISTRY: ToolEntry[] = [
 // registers matching tools with the MCP server.
 // ---------------------------------------------------------------------------
 
-export function registerAllTools(server: McpServer, client: OmadaClient, activeCategories?: Map<ToolCategory, Set<ToolPermission>>): void {
+export function registerAllTools(server: McpServer, client: OmadaClient, filter?: ToolFilter | Map<ToolCategory, Set<ToolPermission>>): void {
     // If no filter map provided, register everything (backward-compat / tests)
-    if (!activeCategories) {
+    if (!filter) {
         for (const entry of TOOL_REGISTRY) {
             entry.fn(server, client);
         }
         return;
     }
 
+    const activeCategories = filter instanceof Map ? filter : filter.categories;
+    const activeProfiles = filter instanceof Map ? new Set() : filter.profiles;
+
     // Deduplicate: some tools appear in multiple categories; track which fns we've already called.
     const registered = new Set<(server: McpServer, client: OmadaClient) => void>();
 
     let toolCount = 0;
+    if (activeProfiles.has('default')) {
+        for (const entry of TOOL_REGISTRY) {
+            if (!DEFAULT_TOOL_FNS.has(entry.fn)) continue;
+            if (registered.has(entry.fn)) continue;
+
+            registered.add(entry.fn);
+            entry.fn(server, client);
+            toolCount++;
+        }
+    }
+
     for (const entry of TOOL_REGISTRY) {
         const allowed = activeCategories.get(entry.category);
         if (!allowed) continue;
@@ -849,8 +926,10 @@ export function registerAllTools(server: McpServer, client: OmadaClient, activeC
             return `${cat}:${p}`;
         })
         .join(', ');
+    const profileList = [...activeProfiles].join(', ');
 
     logger.info('Tool categories loaded', {
+        profiles: profileList || undefined,
         categories: categoryList,
         toolCount,
     });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,7 +3,19 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ToolCategory, ToolPermission } from '../config.js';
 import type { OmadaClient } from '../omadaClient/index.js';
 import { logger } from '../utils/logger.js';
+import { registerAdoptDeviceTool } from './adoptDevice.js';
+import { registerBatchSetSwitchPortNameTool } from './batchSetSwitchPortName.js';
+import { registerBatchSetSwitchPortPoeTool } from './batchSetSwitchPortPoe.js';
+import { registerBatchSetSwitchPortProfileTool } from './batchSetSwitchPortProfile.js';
+import { registerBatchSetSwitchPortStatusTool } from './batchSetSwitchPortStatus.js';
+import { registerBlockClientTool } from './blockClient.js';
+import { registerCreateFirewallAclTool } from './createFirewallAcl.js';
+import { registerCreateLanNetworkTool } from './createLanNetwork.js';
+import { registerCreateLanProfileTool } from './createLanProfile.js';
+import { registerDeleteFirewallAclTool } from './deleteFirewallAcl.js';
+import { registerDeleteLanNetworkTool } from './deleteLanNetwork.js';
 import { registerDisableClientRateLimitTool } from './disableClientRateLimit.js';
+import { registerGenericApiCallTool } from './genericApiCall.js';
 import { registerGetAccessControlTool } from './getAccessControl.js';
 import { registerGetAclConfigTypeSettingTool } from './getAclConfigTypeSetting.js';
 import { registerGetAdvancedVpnSettingTool } from './getAdvancedVpnSetting.js';
@@ -44,6 +56,7 @@ import { registerGetBeaconControlSettingTool } from './getBeaconControlSetting.j
 import { registerGetBuiltinRadiusUsersTool } from './getBuiltinRadiusUsers.js';
 import { registerGetCableTestFullResultsTool } from './getCableTestFullResults.js';
 import { registerGetCableTestLogsTool } from './getCableTestLogs.js';
+import { registerGetCableTestResultsTool } from './getCableTestResults.js';
 import { registerGetCertificateTool } from './getCertificate.js';
 import { registerGetChannelLimitSettingTool } from './getChannelLimitSetting.js';
 import { registerGetChannelsTool } from './getChannels.js';
@@ -82,6 +95,7 @@ import { registerGetDscpConfigTool } from './getDscpConfig.js';
 import { registerGetEapDot1xSettingTool } from './getEapDot1xSetting.js';
 import { registerGetExperienceImprovementTool } from './getExperienceImprovement.js';
 import { registerGetFirewallSettingTool } from './getFirewallSetting.js';
+import { registerGetFirmwareDetailsTool } from './getFirmwareDetails.js';
 import { registerGetFirmwareInfoTool } from './getFirmwareInfo.js';
 import { registerGetFirmwareUpgradePlanTool } from './getFirmwareUpgradePlan.js';
 import { registerGetGatewayDetailTool } from './getGatewayDetail.js';
@@ -242,9 +256,12 @@ import { registerGetSslVpnServerSettingTool } from './getSslVpnServerSetting.js'
 import { registerGetStackNetworkListTool } from './getStackNetworkList.js';
 import { registerGetStackPortsTool } from './getStackPorts.js';
 import { registerGetStaticRoutingInterfaceListTool } from './getStaticRoutingInterfaceList.js';
+import { registerGetSwitchTool } from './getSwitch.js';
 import { registerGetSwitchDetailTool } from './getSwitchDetail.js';
 import { registerGetSwitchDot1xSettingTool } from './getSwitchDot1xSetting.js';
 import { registerGetSwitchGeneralConfigTool } from './getSwitchGeneralConfig.js';
+import { registerGetSwitchNetworksTool } from './getSwitchNetworks.js';
+import { registerGetSwitchPortsTool } from './getSwitchPorts.js';
 import { registerGetSwitchStackDetailTool } from './getSwitchStackDetail.js';
 import { registerGetSwitchVlanInterfaceTool } from './getSwitchVlanInterface.js';
 import { registerGetSyslogConfigTool } from './getSyslogConfig.js';
@@ -299,9 +316,13 @@ import { registerListClientToSiteVpnServersTool } from './listClientToSiteVpnSer
 import { registerListDevicesTool } from './listDevices.js';
 import { registerListDevicesStatsTool } from './listDevicesStats.js';
 import { registerListEapAclsTool } from './listEapAcls.js';
+import { registerListEventsTool } from './listEvents.js';
+import { registerListFirewallAclsTool } from './listFirewallAcls.js';
 import { registerListGlobalAlertsTool } from './listGlobalAlerts.js';
 import { registerListGlobalEventsTool } from './listGlobalEvents.js';
 import { registerListGroupProfilesTool } from './listGroupProfiles.js';
+import { registerListIpGroupsTool } from './listIpGroups.js';
+import { registerListLogsTool } from './listLogs.js';
 import { registerListMdnsProfileTool } from './listMdnsProfile.js';
 import { registerListMostActiveClientsTool } from './listMostActiveClients.js';
 import { registerListOsgAclsTool } from './listOsgAcls.js';
@@ -309,6 +330,7 @@ import { registerListPendingDevicesTool } from './listPendingDevices.js';
 import { registerListPolicyRoutesTool } from './listPolicyRoutes.js';
 import { registerListPortForwardingRulesTool } from './listPortForwardingRules.js';
 import { registerListRadiusProfilesTool } from './listRadiusProfiles.js';
+import { registerListRoutesTool } from './listRoutes.js';
 import { registerListServiceTypeTool } from './listServiceType.js';
 import { registerListSiteAlertsTool } from './listSiteAlerts.js';
 import { registerListSiteAuditLogsTool } from './listSiteAuditLogs.js';
@@ -327,9 +349,27 @@ import { registerListUpgradeFirmwaresTool } from './listUpgradeFirmwares.js';
 import { registerListUpgradeOverviewFirmwaresTool } from './listUpgradeOverviewFirmwares.js';
 import { registerListWireguardTool } from './listWireguard.js';
 import { registerListWireguardPeersTool } from './listWireguardPeers.js';
+import { registerRebootDeviceTool } from './rebootDevice.js';
+import { registerReconnectClientTool } from './reconnectClient.js';
 import { registerSearchDevicesTool } from './searchDevices.js';
 import { registerSetClientRateLimitTool } from './setClientRateLimit.js';
 import { registerSetClientRateLimitProfileTool } from './setClientRateLimitProfile.js';
+import { registerSetDeviceLedTool } from './setDeviceLed.js';
+import { registerSetGatewayWanConnectTool } from './setGatewayWanConnect.js';
+import { registerSetSwitchNetworksTool } from './setSwitchNetworks.js';
+import { registerSetSwitchPortNameTool } from './setSwitchPortName.js';
+import { registerSetSwitchPortPoeTool } from './setSwitchPortPoe.js';
+import { registerSetSwitchPortProfileTool } from './setSwitchPortProfile.js';
+import { registerSetSwitchPortProfileOverrideTool } from './setSwitchPortProfileOverride.js';
+import { registerSetSwitchPortStatusTool } from './setSwitchPortStatus.js';
+import { registerStartCableTestTool } from './startCableTest.js';
+import { registerStartFirmwareUpgradeTool } from './startFirmwareUpgrade.js';
+import { registerUnblockClientTool } from './unblockClient.js';
+import { registerUpdateClientTool } from './updateClient.js';
+import { registerUpdateFirewallSettingTool } from './updateFirewallSetting.js';
+import { registerUpdateLanNetworkTool } from './updateLanNetwork.js';
+import { registerUpdateLanProfileTool } from './updateLanProfile.js';
+import { registerUpdateSwitchPortTool } from './updateSwitchPort.js';
 
 // ---------------------------------------------------------------------------
 // Tool registry: each entry maps a register-function to its category and
@@ -374,6 +414,11 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerListUpgradeOverviewFirmwaresTool, category: 'devices-general', permission: 'read' },
     { fn: registerListSitesStacksTool, category: 'devices-general', permission: 'read' },
     { fn: registerGetSitesDeviceWhiteListTool, category: 'devices-general', permission: 'read' },
+    { fn: registerGetFirmwareDetailsTool, category: 'devices-general', permission: 'read' },
+    { fn: registerRebootDeviceTool, category: 'devices-general', permission: 'write' },
+    { fn: registerAdoptDeviceTool, category: 'devices-general', permission: 'write' },
+    { fn: registerSetDeviceLedTool, category: 'devices-general', permission: 'write' },
+    { fn: registerStartFirmwareUpgradeTool, category: 'devices-general', permission: 'write' },
 
     // --- Devices (switch) ---
     { fn: registerGetSwitchStackDetailTool, category: 'devices-switch', permission: 'read' },
@@ -390,6 +435,22 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerGetSitesSwitchesEsGeneralConfigTool, category: 'devices-switch', permission: 'read' },
     { fn: registerListSitesCableTestSwitchesPortsTool, category: 'devices-switch', permission: 'read' },
     { fn: registerListSitesCableTestSwitchesIncrementResultsTool, category: 'devices-switch', permission: 'read' },
+    { fn: registerGetSwitchTool, category: 'devices-switch', permission: 'read' },
+    { fn: registerGetSwitchPortsTool, category: 'devices-switch', permission: 'read' },
+    { fn: registerGetCableTestResultsTool, category: 'devices-switch', permission: 'read' },
+    { fn: registerGetSwitchNetworksTool, category: 'devices-switch', permission: 'read' },
+    { fn: registerUpdateSwitchPortTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerSetSwitchPortProfileTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerSetSwitchPortPoeTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerSetSwitchPortNameTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerSetSwitchPortStatusTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerSetSwitchPortProfileOverrideTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerBatchSetSwitchPortProfileTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerBatchSetSwitchPortPoeTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerBatchSetSwitchPortStatusTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerBatchSetSwitchPortNameTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerStartCableTestTool, category: 'devices-switch', permission: 'write' },
+    { fn: registerSetSwitchNetworksTool, category: 'devices-switch', permission: 'write' },
 
     // --- Devices (AP) ---
     { fn: registerGetApDetailTool, category: 'devices-ap', permission: 'read' },
@@ -433,6 +494,10 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerSetClientRateLimitTool, category: 'clients', permission: 'write' },
     { fn: registerSetClientRateLimitProfileTool, category: 'clients', permission: 'write' },
     { fn: registerDisableClientRateLimitTool, category: 'clients', permission: 'write' },
+    { fn: registerBlockClientTool, category: 'clients', permission: 'write' },
+    { fn: registerUnblockClientTool, category: 'clients', permission: 'write' },
+    { fn: registerReconnectClientTool, category: 'clients', permission: 'write' },
+    { fn: registerUpdateClientTool, category: 'clients', permission: 'write' },
 
     // --- Client insights ---
     { fn: registerListMostActiveClientsTool, category: 'client-insights', permission: 'read' },
@@ -470,6 +535,7 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerGetWanHealthDetailTool, category: 'network-wan', permission: 'read' },
     { fn: registerGetWanUsageStatsTool, category: 'network-wan', permission: 'read' },
     { fn: registerGetWanNatConfigTool, category: 'network-wan', permission: 'read' },
+    { fn: registerSetGatewayWanConnectTool, category: 'network-wan', permission: 'write' },
 
     // --- Network LAN ---
     { fn: registerGetLanNetworkListTool, category: 'network-lan', permission: 'read' },
@@ -487,6 +553,11 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerGetLanDnsRulesTool, category: 'network-lan', permission: 'read' },
     { fn: registerGetLanProfileEsUsageTool, category: 'network-lan', permission: 'read' },
     { fn: registerGetLanClientCountTool, category: 'network-lan', permission: 'read' },
+    { fn: registerCreateLanNetworkTool, category: 'network-lan', permission: 'write' },
+    { fn: registerUpdateLanNetworkTool, category: 'network-lan', permission: 'write' },
+    { fn: registerDeleteLanNetworkTool, category: 'network-lan', permission: 'write' },
+    { fn: registerCreateLanProfileTool, category: 'network-lan', permission: 'write' },
+    { fn: registerUpdateLanProfileTool, category: 'network-lan', permission: 'write' },
 
     // --- Network NAT ---
     { fn: registerGetPortForwardingStatusTool, category: 'network-nat', permission: 'read' },
@@ -501,6 +572,7 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerListPolicyRoutesTool, category: 'network-routing', permission: 'read' },
     { fn: registerGetGridPolicyRoutingTool, category: 'network-routing', permission: 'read' },
     { fn: registerGetRoutingTableTool, category: 'network-routing', permission: 'read' },
+    { fn: registerListRoutesTool, category: 'network-routing', permission: 'read' },
     { fn: registerGetOspfProcessTool, category: 'network-routing', permission: 'read' },
     { fn: registerGetOspfInterfaceTool, category: 'network-routing', permission: 'read' },
     { fn: registerGetVrrpConfigTool, category: 'network-routing', permission: 'read' },
@@ -570,6 +642,11 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerGetDot1xConfigTool, category: 'firewall-acl', permission: 'read' },
     { fn: registerGetRadiusProxyConfigTool, category: 'firewall-acl', permission: 'read' },
     { fn: registerGetApplicationAclTool, category: 'firewall-acl', permission: 'read' },
+    { fn: registerListFirewallAclsTool, category: 'firewall-acl', permission: 'read' },
+    { fn: registerListIpGroupsTool, category: 'firewall-acl', permission: 'read' },
+    { fn: registerCreateFirewallAclTool, category: 'firewall-acl', permission: 'write' },
+    { fn: registerDeleteFirewallAclTool, category: 'firewall-acl', permission: 'write' },
+    { fn: registerUpdateFirewallSettingTool, category: 'firewall-acl', permission: 'write' },
 
     // --- Firewall traffic ---
     { fn: registerGetUrlFilterGeneralTool, category: 'firewall-traffic', permission: 'read' },
@@ -658,6 +735,8 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerListSiteAuditLogsTool, category: 'logs', permission: 'read' },
     { fn: registerListGlobalEventsTool, category: 'logs', permission: 'read' },
     { fn: registerListGlobalAlertsTool, category: 'logs', permission: 'read' },
+    { fn: registerListEventsTool, category: 'logs', permission: 'read' },
+    { fn: registerListLogsTool, category: 'logs', permission: 'read' },
     { fn: registerGetLogSettingForSiteTool, category: 'logs', permission: 'read' },
     { fn: registerGetLogSettingForSiteV2Tool, category: 'logs', permission: 'read' },
     { fn: registerGetAuditLogSettingForSiteTool, category: 'logs', permission: 'read' },
@@ -685,6 +764,7 @@ const TOOL_REGISTRY: ToolEntry[] = [
     { fn: registerGetWebhookForGlobalTool, category: 'controller', permission: 'read' },
     { fn: registerGetWebhookLogsForGlobalTool, category: 'controller', permission: 'read' },
     { fn: registerGetMailServerStatusTool, category: 'controller', permission: 'read' },
+    { fn: registerGenericApiCallTool, category: 'controller', permission: 'write' },
 
     // --- Maintenance ---
     { fn: registerGetBackupFileListTool, category: 'maintenance', permission: 'read' },

--- a/src/tools/listEvents.ts
+++ b/src/tools/listEvents.ts
@@ -1,0 +1,22 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const listEventsSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    page: z.number().int().min(1).optional().default(1).describe('Page number (default: 1)'),
+    pageSize: z.number().int().min(1).max(1000).optional().default(10).describe('Page size (default: 10, max: 1000)'),
+});
+
+export function registerListEventsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'listEvents',
+        {
+            description: 'List paginated events for a site (alerts, warnings, system events).',
+            inputSchema: listEventsSchema.shape,
+        },
+        wrapToolHandler('listEvents', async ({ siteId, page, pageSize }) => toToolResult(await client.listEvents(siteId, page, pageSize)))
+    );
+}

--- a/src/tools/listFirewallAcls.ts
+++ b/src/tools/listFirewallAcls.ts
@@ -1,0 +1,15 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerListFirewallAclsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'listFirewallAcls',
+        {
+            description: 'List firewall ACL rules for a site (access control lists for inter-VLAN traffic, etc.).',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('listFirewallAcls', async ({ siteId }) => toToolResult(await client.listFirewallAcls(siteId)))
+    );
+}

--- a/src/tools/listIpGroups.ts
+++ b/src/tools/listIpGroups.ts
@@ -1,0 +1,17 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerListIpGroupsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'listIpGroups',
+        {
+            description:
+                'List IP/port groups configured in a site. Groups can be used in firewall ACL rules. ' +
+                'Requires the internal web UI API (OMADA_WEB_USERNAME/OMADA_WEB_PASSWORD).',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('listIpGroups', async ({ siteId }) => toToolResult(await client.listIpGroups(siteId)))
+    );
+}

--- a/src/tools/listLogs.ts
+++ b/src/tools/listLogs.ts
@@ -1,0 +1,22 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const listLogsSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    page: z.number().int().min(1).optional().default(1).describe('Page number (default: 1)'),
+    pageSize: z.number().int().min(1).max(1000).optional().default(10).describe('Page size (default: 10, max: 1000)'),
+});
+
+export function registerListLogsTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'listLogs',
+        {
+            description: 'List paginated logs for a site (system logs, configuration changes).',
+            inputSchema: listLogsSchema.shape,
+        },
+        wrapToolHandler('listLogs', async ({ siteId, page, pageSize }) => toToolResult(await client.listLogs(siteId, page, pageSize)))
+    );
+}

--- a/src/tools/listRoutes.ts
+++ b/src/tools/listRoutes.ts
@@ -1,0 +1,15 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { siteInputSchema, toToolResult, wrapToolHandler } from '../server/common.js';
+
+export function registerListRoutesTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'listRoutes',
+        {
+            description: 'List static routes configured for a site.',
+            inputSchema: siteInputSchema.shape,
+        },
+        wrapToolHandler('listRoutes', async ({ siteId }) => toToolResult(await client.listRoutes(siteId)))
+    );
+}

--- a/src/tools/rebootDevice.ts
+++ b/src/tools/rebootDevice.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const rebootDeviceSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    deviceMac: z.string().min(1, 'deviceMac is required'),
+});
+
+export function registerRebootDeviceTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'rebootDevice',
+        {
+            description: 'Reboot a network device by its MAC address.',
+            inputSchema: rebootDeviceSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('rebootDevice', async ({ deviceMac, siteId }) => toToolResult(await client.rebootDevice(deviceMac, siteId)))
+    );
+}

--- a/src/tools/reconnectClient.ts
+++ b/src/tools/reconnectClient.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const reconnectClientSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    clientMac: z.string().min(1, 'clientMac is required'),
+});
+
+export function registerReconnectClientTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'reconnectClient',
+        {
+            description: 'Force a client to reconnect to the network by its MAC address.',
+            inputSchema: reconnectClientSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('reconnectClient', async ({ clientMac, siteId }) => toToolResult(await client.reconnectClient(clientMac, siteId)))
+    );
+}

--- a/src/tools/setDeviceLed.ts
+++ b/src/tools/setDeviceLed.ts
@@ -1,0 +1,27 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setDeviceLedSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    deviceMac: z.string().min(1, 'deviceMac is required'),
+    ledSetting: z.number().int().min(0).max(2).describe('LED setting: 0=off, 1=on, 2=site-default'),
+});
+
+export function registerSetDeviceLedTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setDeviceLed',
+        {
+            description: 'Set the LED on/off/site-default for a device by its MAC address.',
+            inputSchema: setDeviceLedSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setDeviceLed', async ({ deviceMac, ledSetting, siteId }) =>
+            toToolResult(await client.setDeviceLed(deviceMac, ledSetting, siteId))
+        )
+    );
+}

--- a/src/tools/setGatewayWanConnect.ts
+++ b/src/tools/setGatewayWanConnect.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setGatewayWanConnectSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    gatewayMac: z.string().min(1, 'gatewayMac is required'),
+    portId: z.string().min(1, 'portId is required'),
+    action: z.enum(['connect', 'disconnect']).describe('Whether to connect or disconnect the WAN port'),
+});
+
+export function registerSetGatewayWanConnectTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setGatewayWanConnect',
+        {
+            description: 'Connect or disconnect a gateway WAN port.',
+            inputSchema: setGatewayWanConnectSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setGatewayWanConnect', async ({ gatewayMac, portId, action, siteId }) =>
+            toToolResult(await client.setGatewayWanConnect(gatewayMac, portId, action, siteId))
+        )
+    );
+}

--- a/src/tools/setSwitchNetworks.ts
+++ b/src/tools/setSwitchNetworks.ts
@@ -1,0 +1,27 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setSwitchNetworksSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    data: z.record(z.string(), z.unknown()).describe('Switch network / VLAN trunking configuration payload'),
+});
+
+export function registerSetSwitchNetworksTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setSwitchNetworks',
+        {
+            description: 'Set switch networks / VLAN trunking configuration for a switch.',
+            inputSchema: setSwitchNetworksSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setSwitchNetworks', async ({ switchMac, data, siteId }) =>
+            toToolResult(await client.setSwitchNetworks(switchMac, data, siteId))
+        )
+    );
+}

--- a/src/tools/setSwitchPortName.ts
+++ b/src/tools/setSwitchPortName.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setSwitchPortNameSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    port: z.number().int().min(1, 'port number is required'),
+    name: z.string().min(1).max(128, 'name must be 1-128 characters'),
+});
+
+export function registerSetSwitchPortNameTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setSwitchPortName',
+        {
+            description: 'Set the name of a single switch port (1-128 characters).',
+            inputSchema: setSwitchPortNameSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setSwitchPortName', async ({ switchMac, port, name, siteId }) =>
+            toToolResult(await client.setSwitchPortName(switchMac, port, name, siteId))
+        )
+    );
+}

--- a/src/tools/setSwitchPortPoe.ts
+++ b/src/tools/setSwitchPortPoe.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setSwitchPortPoeSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    port: z.number().int().min(1, 'port number is required'),
+    poeMode: z.number().int().min(0).max(1).describe('1=on (802.3at/af), 0=off'),
+});
+
+export function registerSetSwitchPortPoeTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setSwitchPortPoe',
+        {
+            description: 'Enable or disable PoE on a single switch port. 1=on (802.3at/af), 0=off.',
+            inputSchema: setSwitchPortPoeSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setSwitchPortPoe', async ({ switchMac, port, poeMode, siteId }) =>
+            toToolResult(await client.setSwitchPortPoe(switchMac, port, poeMode, siteId))
+        )
+    );
+}

--- a/src/tools/setSwitchPortProfile.ts
+++ b/src/tools/setSwitchPortProfile.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setSwitchPortProfileSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    port: z.number().int().min(1, 'port number is required'),
+    profileId: z.string().min(1, 'profileId is required'),
+});
+
+export function registerSetSwitchPortProfileTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setSwitchPortProfile',
+        {
+            description: 'Assign a LAN profile to a single switch port.',
+            inputSchema: setSwitchPortProfileSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setSwitchPortProfile', async ({ switchMac, port, profileId, siteId }) =>
+            toToolResult(await client.setSwitchPortProfile(switchMac, port, profileId, siteId))
+        )
+    );
+}

--- a/src/tools/setSwitchPortProfileOverride.ts
+++ b/src/tools/setSwitchPortProfileOverride.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setSwitchPortProfileOverrideSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    port: z.number().int().min(1, 'port number is required'),
+    profileOverrideEnable: z.boolean().describe('Enable or disable profile override'),
+});
+
+export function registerSetSwitchPortProfileOverrideTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setSwitchPortProfileOverride',
+        {
+            description: 'Enable or disable profile override on a single switch port.',
+            inputSchema: setSwitchPortProfileOverrideSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setSwitchPortProfileOverride', async ({ switchMac, port, profileOverrideEnable, siteId }) =>
+            toToolResult(await client.setSwitchPortProfileOverride(switchMac, port, profileOverrideEnable, siteId))
+        )
+    );
+}

--- a/src/tools/setSwitchPortStatus.ts
+++ b/src/tools/setSwitchPortStatus.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const setSwitchPortStatusSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    port: z.number().int().min(1, 'port number is required'),
+    status: z.number().int().min(0).max(1).describe('0=off, 1=on'),
+});
+
+export function registerSetSwitchPortStatusTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'setSwitchPortStatus',
+        {
+            description: 'Enable or disable a single switch port. 0=off, 1=on.',
+            inputSchema: setSwitchPortStatusSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('setSwitchPortStatus', async ({ switchMac, port, status, siteId }) =>
+            toToolResult(await client.setSwitchPortStatus(switchMac, port, status, siteId))
+        )
+    );
+}

--- a/src/tools/startCableTest.ts
+++ b/src/tools/startCableTest.ts
@@ -1,0 +1,21 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const startCableTestSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+});
+
+export function registerStartCableTestTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'startCableTest',
+        {
+            description: 'Start a cable test on a switch. Use getCableTestResults to retrieve results after completion.',
+            inputSchema: startCableTestSchema.shape,
+        },
+        wrapToolHandler('startCableTest', async ({ switchMac, siteId }) => toToolResult(await client.startCableTest(switchMac, siteId)))
+    );
+}

--- a/src/tools/startFirmwareUpgrade.ts
+++ b/src/tools/startFirmwareUpgrade.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const startFirmwareUpgradeSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    deviceMac: z.string().min(1, 'deviceMac is required'),
+});
+
+export function registerStartFirmwareUpgradeTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'startFirmwareUpgrade',
+        {
+            description: 'Start a firmware upgrade for a device. Use getFirmwareDetails first to check for available updates.',
+            inputSchema: startFirmwareUpgradeSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('startFirmwareUpgrade', async ({ deviceMac, siteId }) => toToolResult(await client.startFirmwareUpgrade(deviceMac, siteId)))
+    );
+}

--- a/src/tools/unblockClient.ts
+++ b/src/tools/unblockClient.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const unblockClientSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    clientMac: z.string().min(1, 'clientMac is required'),
+});
+
+export function registerUnblockClientTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'unblockClient',
+        {
+            description: 'Unblock a previously blocked client device by its MAC address, restoring network access.',
+            inputSchema: unblockClientSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('unblockClient', async ({ clientMac, siteId }) => toToolResult(await client.unblockClient(clientMac, siteId)))
+    );
+}

--- a/src/tools/updateClient.ts
+++ b/src/tools/updateClient.ts
@@ -1,0 +1,29 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const updateClientSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    clientMac: z.string().min(1, 'clientMac is required'),
+    name: z.string().optional().describe('Display name for the client'),
+    fixedIp: z.string().optional().describe('Static DHCP IP address'),
+    rateLimitEnable: z.boolean().optional().describe('Enable rate limiting'),
+    upLimit: z.number().int().optional().describe('Upload rate limit (kbps)'),
+    downLimit: z.number().int().optional().describe('Download rate limit (kbps)'),
+});
+
+export function registerUpdateClientTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'updateClient',
+        {
+            description: 'Update client settings such as display name, static IP, and rate limits.',
+            inputSchema: updateClientSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('updateClient', async ({ siteId, clientMac, ...data }) => toToolResult(await client.updateClient(clientMac, data, siteId)))
+    );
+}

--- a/src/tools/updateFirewallSetting.ts
+++ b/src/tools/updateFirewallSetting.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const updateFirewallSettingSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    settings: z.record(z.unknown()).describe('Firewall settings object (same shape returned by getFirewallSetting)'),
+});
+
+export function registerUpdateFirewallSettingTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'updateFirewallSetting',
+        {
+            description:
+                'Update firewall settings for a site. Pass the same shape returned by getFirewallSetting ' +
+                '(broadcastPing, sendRedirects, synCookies, etc.).',
+            inputSchema: updateFirewallSettingSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('updateFirewallSetting', async ({ siteId, settings }) => toToolResult(await client.updateFirewallSetting(settings, siteId)))
+    );
+}

--- a/src/tools/updateLanNetwork.ts
+++ b/src/tools/updateLanNetwork.ts
@@ -1,0 +1,39 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const dhcpSettingsSchema = z.object({
+    enable: z.boolean().describe('Whether DHCP is enabled'),
+    ipRangeStart: z.string().min(1).describe('DHCP range start IP (e.g. "192.168.10.100")'),
+    ipRangeEnd: z.string().min(1).describe('DHCP range end IP (e.g. "192.168.10.200")'),
+    leaseTime: z.number().int().describe('DHCP lease time in seconds'),
+});
+
+const updateLanNetworkSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    networkId: z.string().min(1, 'networkId is required'),
+    name: z.string().min(1, 'Network name is required'),
+    vlan: z.number().int().describe('VLAN ID'),
+    gatewaySubnet: z.string().min(1).describe('Gateway and subnet in CIDR notation (e.g. "192.168.10.1/24")'),
+    purpose: z.number().int().describe('Network purpose (1 = interface)'),
+    igmpSnoopEnable: z.boolean().describe('Whether IGMP snooping is enabled'),
+    dhcpSettings: dhcpSettingsSchema.describe('DHCP server settings'),
+});
+
+export function registerUpdateLanNetworkTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'updateLanNetwork',
+        {
+            description: 'Update an existing LAN network configuration including VLAN, gateway/subnet, and DHCP settings.',
+            inputSchema: updateLanNetworkSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('updateLanNetwork', async ({ siteId, networkId, ...data }) =>
+            toToolResult(await client.updateLanNetwork(networkId, data, siteId))
+        )
+    );
+}

--- a/src/tools/updateLanProfile.ts
+++ b/src/tools/updateLanProfile.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const updateLanProfileSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    profileId: z.string().min(1, 'profileId is required'),
+    name: z.string().min(1, 'Profile name is required'),
+    nativeNetworkId: z.string().min(1).describe('Native (untagged) network ID'),
+    tagNetworkIds: z.array(z.string().min(1)).describe('Tagged network IDs'),
+    poe: z.boolean().describe('Whether PoE is enabled'),
+    spanningTreeEnable: z.boolean().describe('Whether Spanning Tree Protocol is enabled'),
+    loopbackDetectEnable: z.boolean().describe('Whether loopback detection is enabled'),
+    portIsolationEnable: z.boolean().describe('Whether port isolation is enabled'),
+    lldpMedEnable: z.boolean().describe('Whether LLDP-MED is enabled'),
+});
+
+export function registerUpdateLanProfileTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'updateLanProfile',
+        {
+            description: 'Update an existing LAN profile configuration including network assignments and port settings.',
+            inputSchema: updateLanProfileSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('updateLanProfile', async ({ siteId, profileId, ...data }) =>
+            toToolResult(await client.updateLanProfile(profileId, data, siteId))
+        )
+    );
+}

--- a/src/tools/updateSwitchPort.ts
+++ b/src/tools/updateSwitchPort.ts
@@ -1,0 +1,36 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type { OmadaClient } from '../omadaClient/index.js';
+import { toToolResult, wrapToolHandler } from '../server/common.js';
+
+const updateSwitchPortSchema = z.object({
+    siteId: z.string().min(1).optional(),
+    switchMac: z.string().min(1, 'switchMac is required'),
+    portId: z.string().min(1, 'portId is required'),
+    profileId: z.string().min(1).optional().describe('LAN profile ID to assign'),
+    poe: z.boolean().optional().describe('Enable or disable PoE'),
+    bandwidthLimitMode: z.number().int().optional().describe('Bandwidth limit mode'),
+    linkSpeed: z.number().int().optional().describe('Link speed setting'),
+    duplex: z.number().int().optional().describe('Duplex mode'),
+    spanningTreeEnable: z.boolean().optional().describe('Enable Spanning Tree Protocol'),
+    portIsolationEnable: z.boolean().optional().describe('Enable port isolation'),
+    loopbackDetectEnable: z.boolean().optional().describe('Enable loopback detection'),
+    lldpMedEnable: z.boolean().optional().describe('Enable LLDP-MED'),
+});
+
+export function registerUpdateSwitchPortTool(server: McpServer, client: OmadaClient): void {
+    server.registerTool(
+        'updateSwitchPort',
+        {
+            description: 'Update a switch port configuration (profile, PoE, speed, STP, isolation, etc.).',
+            inputSchema: updateSwitchPortSchema.shape,
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        wrapToolHandler('updateSwitchPort', async ({ siteId, switchMac, portId, ...data }) =>
+            toToolResult(await client.updateSwitchPort(switchMac, portId, data, siteId))
+        )
+    );
+}

--- a/src/utils/omada-headers.ts
+++ b/src/utils/omada-headers.ts
@@ -7,11 +7,26 @@ import type { EnvironmentConfig, OmadaConnectionConfig } from '../config.js';
  * All other Omada configuration must come from environment variables.
  */
 export function extractAuthFromHeaders(headers: IncomingHttpHeaders): {
+    authMode?: 'oauth' | 'web';
     clientId?: string;
     clientSecret?: string;
+    webUsername?: string;
+    webPassword?: string;
     omadacId?: string;
 } {
-    const result: { clientId?: string; clientSecret?: string; omadacId?: string } = {};
+    const result: {
+        authMode?: 'oauth' | 'web';
+        clientId?: string;
+        clientSecret?: string;
+        webUsername?: string;
+        webPassword?: string;
+        omadacId?: string;
+    } = {};
+
+    const authMode = headers['x-omada-auth-mode'];
+    if (authMode === 'oauth' || authMode === 'web') {
+        result.authMode = authMode;
+    }
 
     const clientId = headers['x-omada-client-id'];
     if (typeof clientId === 'string' && clientId.length > 0) {
@@ -21,6 +36,16 @@ export function extractAuthFromHeaders(headers: IncomingHttpHeaders): {
     const clientSecret = headers['x-omada-client-secret'];
     if (typeof clientSecret === 'string' && clientSecret.length > 0) {
         result.clientSecret = clientSecret;
+    }
+
+    const webUsername = headers['x-omada-web-username'];
+    if (typeof webUsername === 'string' && webUsername.length > 0) {
+        result.webUsername = webUsername;
+    }
+
+    const webPassword = headers['x-omada-web-password'];
+    if (typeof webPassword === 'string' && webPassword.length > 0) {
+        result.webPassword = webPassword;
     }
 
     const omadacId = headers['x-omada-omadac-id'];
@@ -38,17 +63,33 @@ export function extractAuthFromHeaders(headers: IncomingHttpHeaders): {
  */
 export function resolveOmadaConfig(
     config: EnvironmentConfig,
-    headerAuth: { clientId?: string; clientSecret?: string; omadacId?: string }
+    headerAuth: {
+        authMode?: 'oauth' | 'web';
+        clientId?: string;
+        clientSecret?: string;
+        webUsername?: string;
+        webPassword?: string;
+        omadacId?: string;
+    }
 ): OmadaConnectionConfig {
+    const authMode = headerAuth.authMode ?? config.authMode ?? 'oauth';
     const clientId = config.clientId ?? headerAuth.clientId;
     const clientSecret = config.clientSecret ?? headerAuth.clientSecret;
+    const webUsername = config.webUsername ?? headerAuth.webUsername;
+    const webPassword = config.webPassword ?? headerAuth.webPassword;
     const omadacId = config.omadacId ?? headerAuth.omadacId;
 
-    if (!clientId) {
+    if (authMode === 'oauth' && !clientId) {
         throw new Error('Missing required Omada credentials: set OMADA_CLIENT_ID env var or x-omada-client-id header');
     }
-    if (!clientSecret) {
+    if (authMode === 'oauth' && !clientSecret) {
         throw new Error('Missing required Omada credentials: set OMADA_CLIENT_SECRET env var or x-omada-client-secret header');
+    }
+    if (authMode === 'web' && !webUsername) {
+        throw new Error('Missing required Omada credentials: set OMADA_WEB_USERNAME env var or x-omada-web-username header');
+    }
+    if (authMode === 'web' && !webPassword) {
+        throw new Error('Missing required Omada credentials: set OMADA_WEB_PASSWORD env var or x-omada-web-password header');
     }
     if (!omadacId) {
         throw new Error('Missing required Omada credentials: set OMADA_OMADAC_ID env var or x-omada-omadac-id header');
@@ -56,8 +97,11 @@ export function resolveOmadaConfig(
 
     return {
         baseUrl: config.baseUrl,
+        authMode,
         clientId,
         clientSecret,
+        webUsername,
+        webPassword,
         omadacId,
         siteId: config.siteId,
         strictSsl: config.strictSsl,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -379,15 +379,24 @@ describe('config', () => {
                 httpNgrokEnabled: true,
                 httpNgrokAuthToken: 'ngrok-token-xyz',
             });
-            expect(config.toolCategories).toBeInstanceOf(Map);
+            expect(config.toolCategories.categories).toBeInstanceOf(Map);
+            expect(config.toolCategories.profiles).toBeInstanceOf(Set);
         });
     });
 });
 
 describe('parseToolCategories', () => {
     it('should return empty categories and no warnings for empty string', () => {
-        const { categories, warnings } = parseToolCategories('');
+        const { categories, profiles, warnings } = parseToolCategories('');
         expect(categories.size).toBe(0);
+        expect(profiles.size).toBe(0);
+        expect(warnings).toEqual([]);
+    });
+
+    it('should parse the default profile', () => {
+        const { categories, profiles, warnings } = parseToolCategories('default');
+        expect(categories.size).toBe(0);
+        expect(profiles).toEqual(new Set(['default']));
         expect(warnings).toEqual([]);
     });
 
@@ -441,7 +450,8 @@ describe('parseToolCategories', () => {
     });
 
     it('DEFAULT_TOOL_CATEGORIES should not contain any future categories', () => {
-        const { warnings } = parseToolCategories(DEFAULT_TOOL_CATEGORIES);
+        const { profiles, warnings } = parseToolCategories(DEFAULT_TOOL_CATEGORIES);
+        expect(profiles).toEqual(new Set(['default']));
         expect(warnings.filter((w) => w.includes('future phase'))).toHaveLength(0);
     });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -31,6 +31,7 @@ describe('config', () => {
             expect(config.baseUrl).toBe('https://omada.example.com');
             expect(config.clientId).toBe('test-client-id');
             expect(config.clientSecret).toBe('test-client-secret');
+            expect(config.authMode).toBe('oauth');
             expect(config.omadacId).toBe('test-omadac-id');
             expect(config.siteId).toBeUndefined();
             expect(config.strictSsl).toBe(true); // Default
@@ -72,6 +73,31 @@ describe('config', () => {
 
         it('should throw error if OMADA_OMADAC_ID is missing in stdio mode', () => {
             delete mockEnv.OMADA_OMADAC_ID;
+
+            expect(() => loadConfigFromEnv(mockEnv)).toThrow('Invalid environment configuration');
+        });
+
+        it('should load web auth configuration in stdio mode', () => {
+            mockEnv.OMADA_AUTH_MODE = 'web';
+            delete mockEnv.OMADA_CLIENT_ID;
+            delete mockEnv.OMADA_CLIENT_SECRET;
+            mockEnv.OMADA_WEB_USERNAME = 'web-user';
+            mockEnv.OMADA_WEB_PASSWORD = 'web-pass';
+
+            const config = loadConfigFromEnv(mockEnv);
+
+            expect(config.authMode).toBe('web');
+            expect(config.webUsername).toBe('web-user');
+            expect(config.webPassword).toBe('web-pass');
+            expect(config.clientId).toBeUndefined();
+            expect(config.clientSecret).toBeUndefined();
+        });
+
+        it('should throw if web auth username is missing in stdio mode', () => {
+            mockEnv.OMADA_AUTH_MODE = 'web';
+            delete mockEnv.OMADA_CLIENT_ID;
+            delete mockEnv.OMADA_CLIENT_SECRET;
+            mockEnv.OMADA_WEB_PASSWORD = 'web-pass';
 
             expect(() => loadConfigFromEnv(mockEnv)).toThrow('Invalid environment configuration');
         });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -10,7 +10,7 @@ const baseConfig = {
     strictSsl: true,
     requestTimeout: 15_000,
     httpTransport: 'stream',
-    toolCategories: new Map(),
+    toolCategories: { categories: new Map(), profiles: new Set() },
     startupWarnings: [],
 };
 
@@ -78,7 +78,7 @@ describe('src/index main entry', () => {
 
         expect(mockInitLogger).toHaveBeenCalledWith('info', 'plain', true);
         expect(OmadaClient).toHaveBeenCalledWith(expect.objectContaining({ baseUrl: 'https://controller.local' }));
-        expect(startStdioServer).toHaveBeenCalledWith(expect.objectContaining({ client: 'instance' }), new Map());
+        expect(startStdioServer).toHaveBeenCalledWith(expect.objectContaining({ client: 'instance' }), baseConfig.toolCategories);
         expect(startHttpServer).not.toHaveBeenCalled();
         expect(loggerInfo).toHaveBeenCalledWith(
             'Starting Omada MCP server',

--- a/tests/omadaClient/auth.test.ts
+++ b/tests/omadaClient/auth.test.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AuthManager } from '../../src/omadaClient/auth.js';
+import { AuthManager, WebAuthManager } from '../../src/omadaClient/auth.js';
 import type { OmadaApiResponse, TokenResult } from '../../src/types/index.js';
 import * as loggerModule from '../../src/utils/logger.js';
 
@@ -278,6 +278,45 @@ describe('AuthManager', () => {
             // Next call should re-authenticate
             await authManager.getAccessToken();
             expect(mockHttp.post).toHaveBeenCalledTimes(2);
+        });
+    });
+});
+
+describe('WebAuthManager', () => {
+    let mockHttp: AxiosInstance;
+
+    beforeEach(() => {
+        mockHttp = {
+            defaults: { baseURL: 'https://test.example.com' },
+            post: vi.fn(),
+        } as unknown as AxiosInstance;
+
+        vi.spyOn(loggerModule.logger, 'error').mockImplementation(() => {
+            // Mock implementation
+        });
+        vi.spyOn(loggerModule.logger, 'info').mockImplementation(() => {
+            // Mock implementation
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should login and return CSRF/cookie headers', async () => {
+        (mockHttp.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+            data: { errorCode: 0, msg: 'Success', result: { token: 'csrf-token' } },
+            headers: { 'set-cookie': ['SESSION=abc; Path=/', 'TOKEN=def; Path=/'] },
+        });
+
+        const authManager = new WebAuthManager(mockHttp, 'user', 'pass', 'omadac-id');
+        const headers = await authManager.getAuthHeaders();
+
+        expect(mockHttp.post).toHaveBeenCalledWith('/omadac-id/api/v2/login', { username: 'user', password: 'pass' }, { withCredentials: true });
+        expect(headers).toEqual({
+            'Csrf-Token': 'csrf-token',
+            'Omada-Request-Source': 'web-local',
+            Cookie: 'SESSION=abc; TOKEN=def',
         });
     });
 });

--- a/tests/omadaClient/request.test.ts
+++ b/tests/omadaClient/request.test.ts
@@ -8,8 +8,7 @@ describe('RequestHandler', () => {
         request: ReturnType<typeof vi.fn>;
     };
     let mockAuthManager: {
-        getAccessToken: ReturnType<typeof vi.fn>;
-        refreshAccessToken: ReturnType<typeof vi.fn>;
+        getAuthHeaders: ReturnType<typeof vi.fn>;
         clearToken?: ReturnType<typeof vi.fn>;
     };
 
@@ -19,8 +18,7 @@ describe('RequestHandler', () => {
         };
 
         mockAuthManager = {
-            getAccessToken: vi.fn().mockResolvedValue('test-access-token'),
-            refreshAccessToken: vi.fn().mockResolvedValue(undefined),
+            getAuthHeaders: vi.fn().mockResolvedValue({ Authorization: 'AccessToken=test-access-token' }),
             clearToken: vi.fn(),
         };
 
@@ -42,7 +40,7 @@ describe('RequestHandler', () => {
             const handler = new RequestHandler(mockAxiosInstance as never, mockAuthManager as never);
             const result = await handler.get<{ errorCode: number; msg: string; result: { data: string } }>('/api/test');
 
-            expect(mockAuthManager.getAccessToken).toHaveBeenCalled();
+            expect(mockAuthManager.getAuthHeaders).toHaveBeenCalled();
             expect(mockAxiosInstance.request).toHaveBeenCalledWith(
                 expect.objectContaining({
                     method: 'GET',
@@ -136,7 +134,6 @@ describe('RequestHandler', () => {
 
             await expect(handler.request<unknown>({ method: 'GET', url: '/api/secure' }, false)).rejects.toThrow();
 
-            expect(mockAuthManager.refreshAccessToken).not.toHaveBeenCalled();
             expect(mockAxiosInstance.request).toHaveBeenCalledTimes(1);
         });
 

--- a/tests/server/stream.test.ts
+++ b/tests/server/stream.test.ts
@@ -106,7 +106,7 @@ describe('Stream Server', () => {
             httpNgrokEnabled: false,
             logLevel: 'info',
             logFormat: 'plain',
-            toolCategories: new Map(),
+            toolCategories: { categories: new Map(), profiles: new Set() },
             startupWarnings: [],
         } as EnvironmentConfig;
 
@@ -219,7 +219,10 @@ describe('Stream Server', () => {
         });
 
         it('should pass toolCategories from config to registerAllTools', () => {
-            const toolCategories = new Map<ToolCategory, Set<ToolPermission>>([['dashboard' as ToolCategory, new Set<ToolPermission>(['read'])]]);
+            const toolCategories = {
+                categories: new Map<ToolCategory, Set<ToolPermission>>([['dashboard' as ToolCategory, new Set<ToolPermission>(['read'])]]),
+                profiles: new Set(),
+            };
             const configWithCategories = { ...mockConfig, toolCategories };
             createStreamTransport(mockClient, configWithCategories);
             expect(vi.mocked(registerAllTools)).toHaveBeenCalledWith(expect.anything(), expect.anything(), toolCategories);

--- a/tests/toolCategories.test.ts
+++ b/tests/toolCategories.test.ts
@@ -21,15 +21,16 @@ describe('parseToolCategories', () => {
     // -----------------------------------------------------------------------
 
     it('parses the default OMADA_TOOL_CATEGORIES without error', () => {
-        const { categories } = parseToolCategories(DEFAULT_TOOL_CATEGORIES);
-        expect(categories.size).toBeGreaterThan(0);
+        const { categories, profiles, warnings } = parseToolCategories(DEFAULT_TOOL_CATEGORIES);
+        expect(categories.size).toBe(0);
+        expect(profiles).toEqual(new Set(['default']));
+        expect(warnings).toEqual([]);
     });
 
-    it('default includes dashboard, client-insights, clients with only read', () => {
-        const { categories } = parseToolCategories(DEFAULT_TOOL_CATEGORIES);
-        expect(categories.get('dashboard')).toEqual(new Set(['read']));
-        expect(categories.get('client-insights')).toEqual(new Set(['read']));
-        expect(categories.get('clients')).toEqual(new Set(['read']));
+    it('default profile is not expanded into category permissions', () => {
+        const { categories, profiles } = parseToolCategories(DEFAULT_TOOL_CATEGORIES);
+        expect(categories.size).toBe(0);
+        expect(profiles.has('default')).toBe(true);
     });
 
     it('default does not include insights (future category)', () => {
@@ -37,8 +38,9 @@ describe('parseToolCategories', () => {
         expect(categories.has('insights')).toBe(false);
     });
 
-    it('default expands devices-all:r to all four device categories with read', () => {
-        const { categories } = parseToolCategories(DEFAULT_TOOL_CATEGORIES);
+    it('default can be combined with category filters', () => {
+        const { categories, profiles } = parseToolCategories('default,devices-all:r');
+        expect(profiles.has('default')).toBe(true);
         for (const cat of CATEGORY_GROUP_ALIASES['devices-all']) {
             expect(categories.get(cat)).toEqual(new Set(['read']));
         }
@@ -238,8 +240,9 @@ describe('parseToolCategories', () => {
     });
 
     it('returns empty categories for empty string', () => {
-        const { categories } = parseToolCategories('');
+        const { categories, profiles } = parseToolCategories('');
         expect(categories.size).toBe(0);
+        expect(profiles.size).toBe(0);
     });
 });
 
@@ -285,6 +288,19 @@ describe('registerAllTools category filtering', () => {
     it('registers zero tools when active categories map is empty', () => {
         registerAllTools(mockServer, mockClient, new Map());
         expect(mockServer.registerTool).not.toHaveBeenCalled();
+    });
+
+    it('registers the curated 60-tool set for the default profile', () => {
+        const filter = parseToolCategories('default');
+        registerAllTools(mockServer, mockClient, filter);
+
+        const toolNames = (mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls.map(([name]) => name);
+        expect(mockServer.registerTool).toHaveBeenCalledTimes(60);
+        expect(toolNames).toContain('listSites');
+        expect(toolNames).toContain('listIpGroups');
+        expect(toolNames).toContain('genericApiCall');
+        expect(toolNames).toContain('setSwitchPortProfile');
+        expect(toolNames).not.toContain('getSiteDetail');
     });
 
     it('registers all tools when all:rw is active', () => {

--- a/tests/toolCategories.test.ts
+++ b/tests/toolCategories.test.ts
@@ -273,13 +273,13 @@ describe('registerAllTools category filtering', () => {
         registerAllTools(mockServer, mockClient, activeCategories);
 
         expect((mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
-        // dashboard read tools are a subset of all 327 tools
-        expect((mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThan(327);
+        // dashboard read tools are a subset of all tools
+        expect((mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThan(367);
     });
 
-    it('registers all 327 tools when no activeCategories provided', () => {
+    it('registers all 367 tools when no activeCategories provided', () => {
         registerAllTools(mockServer, mockClient);
-        expect(mockServer.registerTool).toHaveBeenCalledTimes(327);
+        expect(mockServer.registerTool).toHaveBeenCalledTimes(367);
     });
 
     it('registers zero tools when active categories map is empty', () => {
@@ -290,15 +290,14 @@ describe('registerAllTools category filtering', () => {
     it('registers all tools when all:rw is active', () => {
         const { categories: activeCategories } = parseToolCategories('all:rw');
         registerAllTools(mockServer, mockClient, activeCategories);
-        expect(mockServer.registerTool).toHaveBeenCalledTimes(327);
+        expect(mockServer.registerTool).toHaveBeenCalledTimes(367);
     });
 
     it('write-only filter registers only write tools for clients category', () => {
-        // clients:w should only register write tools:
-        // setClientRateLimit, setClientRateLimitProfile, disableClientRateLimit
+        // clients:w should only register write tools.
         const { categories: activeCategories } = parseToolCategories('clients:w');
         registerAllTools(mockServer, mockClient, activeCategories);
-        expect((mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls.length).toBe(3);
+        expect((mockServer.registerTool as ReturnType<typeof vi.fn>).mock.calls.length).toBe(7);
     });
 
     it('logs active categories and tool count on startup', () => {

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -148,7 +148,7 @@ describe('tools/index', () => {
             expect(mockServer.registerTool).toHaveBeenCalledWith('getSitesHealthGatewaysWansDetails', expect.any(Object), expect.any(Function));
 
             // Verify total number of tools registered
-            expect(mockServer.registerTool).toHaveBeenCalledTimes(327);
+            expect(mockServer.registerTool).toHaveBeenCalledTimes(367);
         });
     });
 });

--- a/tests/utils/omada-headers.test.ts
+++ b/tests/utils/omada-headers.test.ts
@@ -4,6 +4,7 @@ import { extractAuthFromHeaders, resolveOmadaConfig } from '../../src/utils/omad
 
 const baseEnvConfig: EnvironmentConfig = {
     baseUrl: 'https://omada.example.com',
+    authMode: 'oauth',
     strictSsl: true,
     logLevel: 'info',
     logFormat: 'plain',
@@ -20,6 +21,7 @@ describe('omada-headers', () => {
     describe('extractAuthFromHeaders', () => {
         it('extracts all three credential fields when present', () => {
             const headers = {
+                'x-omada-auth-mode': 'oauth',
                 'x-omada-client-id': 'my-client-id',
                 'x-omada-client-secret': 'my-secret',
                 'x-omada-omadac-id': 'my-omadac-id',
@@ -27,9 +29,28 @@ describe('omada-headers', () => {
 
             const result = extractAuthFromHeaders(headers);
 
+            expect(result.authMode).toBe('oauth');
             expect(result.clientId).toBe('my-client-id');
             expect(result.clientSecret).toBe('my-secret');
             expect(result.omadacId).toBe('my-omadac-id');
+        });
+
+        it('extracts web auth credential fields when present', () => {
+            const headers = {
+                'x-omada-auth-mode': 'web',
+                'x-omada-web-username': 'web-user',
+                'x-omada-web-password': 'web-pass',
+                'x-omada-omadac-id': 'my-omadac-id',
+            };
+
+            const result = extractAuthFromHeaders(headers);
+
+            expect(result).toEqual({
+                authMode: 'web',
+                webUsername: 'web-user',
+                webPassword: 'web-pass',
+                omadacId: 'my-omadac-id',
+            });
         });
 
         it('returns undefined for missing fields', () => {
@@ -107,6 +128,7 @@ describe('omada-headers', () => {
 
             expect(result.clientId).toBe('env-client-id');
             expect(result.clientSecret).toBe('env-secret');
+            expect(result.authMode).toBe('oauth');
             expect(result.omadacId).toBe('env-omadac-id');
             expect(result.baseUrl).toBe('https://omada.example.com');
             expect(result.strictSsl).toBe(true);
@@ -123,6 +145,23 @@ describe('omada-headers', () => {
 
             expect(result.clientId).toBe('header-client-id');
             expect(result.clientSecret).toBe('header-secret');
+            expect(result.authMode).toBe('oauth');
+            expect(result.omadacId).toBe('header-omadac-id');
+        });
+
+        it('builds web auth config from headers', () => {
+            const config: EnvironmentConfig = { ...baseEnvConfig };
+
+            const result = resolveOmadaConfig(config, {
+                authMode: 'web',
+                webUsername: 'header-user',
+                webPassword: 'header-pass',
+                omadacId: 'header-omadac-id',
+            });
+
+            expect(result.authMode).toBe('web');
+            expect(result.webUsername).toBe('header-user');
+            expect(result.webPassword).toBe('header-pass');
             expect(result.omadacId).toBe('header-omadac-id');
         });
 


### PR DESCRIPTION
## Summary
- Add Fusion/local web-session auth via OMADA_AUTH_MODE=web with CSRF/cookie request headers.
- Port write/action tooling for LAN networks/profiles, firewall ACLs, device/client actions, logs/routes, generic API calls, and switch port management.
- Add internal web UI API support for firewall ACL and IP-group operations when web credentials are configured.
- Document OAuth vs web auth env vars and HTTP credential headers.

## Validation
- npm run check
- npm run build
- npm test -- --run
- docker build -t omada-mcp:miguel-v0.15-fusion .
- Docker MCP stdio smoke with OMADA_TOOL_CATEGORIES=all:rw exposed 367 tools and verified key added tools are present: listIpGroups, genericApiCall, createLanNetwork, setSwitchPortProfile, blockClient.

## Notes
- This branch is based directly on Miguel main/v0.15.0 and is one commit ahead.
- Live authenticated Fusion controller smoke was not rerun here because local credentials were not available in this checkout.