### PR TITLE
fix(log): correct time filter params for site/global events and alerts

### DIFF
--- a/src/omadaClient/log.ts
+++ b/src/omadaClient/log.ts
@@ -36,10 +36,10 @@ export class LogOperations {
         };
 
         if (options.startTime !== undefined) {
-            params['filters.startTime'] = options.startTime;
+            params['filters.timeStart'] = options.startTime;
         }
         if (options.endTime !== undefined) {
-            params['filters.endTime'] = options.endTime;
+            params['filters.timeEnd'] = options.endTime;
         }
         if (options.searchKey) {
             params.searchKey = options.searchKey;
@@ -63,10 +63,10 @@ export class LogOperations {
         };
 
         if (options.startTime !== undefined) {
-            params['filters.startTime'] = options.startTime;
+            params['filters.timeStart'] = options.startTime;
         }
         if (options.endTime !== undefined) {
-            params['filters.endTime'] = options.endTime;
+            params['filters.timeEnd'] = options.endTime;
         }
         if (options.searchKey) {
             params.searchKey = options.searchKey;
@@ -116,10 +116,10 @@ export class LogOperations {
         };
 
         if (options.startTime !== undefined) {
-            params['filters.startTime'] = options.startTime;
+            params['filters.timeStart'] = options.startTime;
         }
         if (options.endTime !== undefined) {
-            params['filters.endTime'] = options.endTime;
+            params['filters.timeEnd'] = options.endTime;
         }
         if (options.searchKey) {
             params.searchKey = options.searchKey;
@@ -142,10 +142,10 @@ export class LogOperations {
         };
 
         if (options.startTime !== undefined) {
-            params['filters.startTime'] = options.startTime;
+            params['filters.timeStart'] = options.startTime;
         }
         if (options.endTime !== undefined) {
-            params['filters.endTime'] = options.endTime;
+            params['filters.timeEnd'] = options.endTime;
         }
         if (options.searchKey) {
             params.searchKey = options.searchKey;

--- a/src/tools/listGlobalAlerts.ts
+++ b/src/tools/listGlobalAlerts.ts
@@ -11,17 +11,13 @@ export function registerListGlobalAlertsTool(server: McpServer, client: OmadaCli
         startTime: z
             .number()
             .int()
-            .optional()
             .describe(
-                'Filter alerts after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Both startTime and endTime must be provided together.'
+                'Filter alerts after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Required by the Omada API.'
             ),
         endTime: z
             .number()
             .int()
-            .optional()
-            .describe(
-                'Filter alerts before this time. Unix timestamp in milliseconds (e.g. Date.now()). Both startTime and endTime must be provided together.'
-            ),
+            .describe('Filter alerts before this time. Unix timestamp in milliseconds (e.g. Date.now()). Required by the Omada API.'),
         searchKey: z.string().optional().describe('Keyword to filter alerts by description or device name.'),
         customHeaders: customHeadersSchema,
     });
@@ -30,7 +26,7 @@ export function registerListGlobalAlertsTool(server: McpServer, client: OmadaCli
         'listGlobalAlerts',
         {
             description:
-                'List alert logs across all sites on the controller: threshold breaches, device failures, security events, etc. Use startTime/endTime (both required if filtering by time) to narrow the range.',
+                'List alert logs across all sites on the controller: threshold breaches, device failures, security events, etc. startTime and endTime are required by the Omada API.',
             inputSchema: inputSchema.shape,
         },
         wrapToolHandler('listGlobalAlerts', async (args) =>

--- a/src/tools/listGlobalEvents.ts
+++ b/src/tools/listGlobalEvents.ts
@@ -11,17 +11,13 @@ export function registerListGlobalEventsTool(server: McpServer, client: OmadaCli
         startTime: z
             .number()
             .int()
-            .optional()
             .describe(
-                'Filter events after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Both startTime and endTime must be provided together.'
+                'Filter events after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Required by the Omada API.'
             ),
         endTime: z
             .number()
             .int()
-            .optional()
-            .describe(
-                'Filter events before this time. Unix timestamp in milliseconds (e.g. Date.now()). Both startTime and endTime must be provided together.'
-            ),
+            .describe('Filter events before this time. Unix timestamp in milliseconds (e.g. Date.now()). Required by the Omada API.'),
         searchKey: z.string().optional().describe('Keyword to filter events by description or device name.'),
         customHeaders: customHeadersSchema,
     });
@@ -30,7 +26,7 @@ export function registerListGlobalEventsTool(server: McpServer, client: OmadaCli
         'listGlobalEvents',
         {
             description:
-                'List system event logs across all sites on the controller. Returns device online/offline, client connect/disconnect, firmware upgrades, config changes, etc. Use startTime/endTime (both required if filtering by time) to narrow the range.',
+                'List system event logs across all sites on the controller. Returns device online/offline, client connect/disconnect, firmware upgrades, config changes, etc. startTime and endTime are required by the Omada API.',
             inputSchema: inputSchema.shape,
         },
         wrapToolHandler('listGlobalEvents', async (args) =>

--- a/src/tools/listSiteAlerts.ts
+++ b/src/tools/listSiteAlerts.ts
@@ -16,17 +16,13 @@ export function registerListSiteAlertsTool(server: McpServer, client: OmadaClien
         startTime: z
             .number()
             .int()
-            .optional()
             .describe(
-                'Filter alerts after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Both startTime and endTime must be provided together.'
+                'Filter alerts after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Required by the Omada API.'
             ),
         endTime: z
             .number()
             .int()
-            .optional()
-            .describe(
-                'Filter alerts before this time. Unix timestamp in milliseconds (e.g. Date.now()). Both startTime and endTime must be provided together.'
-            ),
+            .describe('Filter alerts before this time. Unix timestamp in milliseconds (e.g. Date.now()). Required by the Omada API.'),
         searchKey: z.string().optional().describe('Keyword to filter alerts by description or device name.'),
         customHeaders: customHeadersSchema,
     });
@@ -35,7 +31,7 @@ export function registerListSiteAlertsTool(server: McpServer, client: OmadaClien
         'listSiteAlerts',
         {
             description:
-                'List alert logs for a site: threshold breaches, device failures, security events, and other conditions requiring attention. Returns alert type, severity, device, and timestamp. Use startTime/endTime (both required if filtering by time) to narrow the range.',
+                'List alert logs for a site: threshold breaches, device failures, security events, and other conditions requiring attention. Returns alert type, severity, device, and timestamp. startTime and endTime are required by the Omada API.',
             inputSchema: inputSchema.shape,
         },
         wrapToolHandler('listSiteAlerts', async (args) =>

--- a/src/tools/listSiteEvents.ts
+++ b/src/tools/listSiteEvents.ts
@@ -16,17 +16,13 @@ export function registerListSiteEventsTool(server: McpServer, client: OmadaClien
         startTime: z
             .number()
             .int()
-            .optional()
             .describe(
-                'Filter events after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Both startTime and endTime must be provided together.'
+                'Filter events after this time. Unix timestamp in milliseconds (e.g. Date.now() - 86400000 for last 24h). Required by the Omada API.'
             ),
         endTime: z
             .number()
             .int()
-            .optional()
-            .describe(
-                'Filter events before this time. Unix timestamp in milliseconds (e.g. Date.now()). Both startTime and endTime must be provided together.'
-            ),
+            .describe('Filter events before this time. Unix timestamp in milliseconds (e.g. Date.now()). Required by the Omada API.'),
         searchKey: z.string().optional().describe('Keyword to filter events by description or device name.'),
         customHeaders: customHeadersSchema,
     });
@@ -35,7 +31,7 @@ export function registerListSiteEventsTool(server: McpServer, client: OmadaClien
         'listSiteEvents',
         {
             description:
-                'List system event logs for a site: device online/offline, client connect/disconnect, firmware upgrades, config changes, etc. Returns event type, severity, description, device, and timestamp. Use startTime/endTime (both required if filtering by time) to narrow the range.',
+                'List system event logs for a site: device online/offline, client connect/disconnect, firmware upgrades, config changes, etc. Returns event type, severity, description, device, and timestamp. startTime and endTime are required by the Omada API.',
             inputSchema: inputSchema.shape,
         },
         wrapToolHandler('listSiteEvents', async (args) =>

--- a/tests/omadaClient/log.test.ts
+++ b/tests/omadaClient/log.test.ts
@@ -57,8 +57,8 @@ describe('LogOperations', () => {
             expect(mockRequest.get).toHaveBeenCalledWith(
                 expect.any(String),
                 expect.objectContaining({
-                    'filters.startTime': 1000000,
-                    'filters.endTime': 2000000,
+                    'filters.timeStart': 1000000,
+                    'filters.timeEnd': 2000000,
                     searchKey: 'device',
                 }),
                 undefined
@@ -106,8 +106,8 @@ describe('LogOperations', () => {
             expect(mockRequest.get).toHaveBeenCalledWith(
                 expect.any(String),
                 expect.objectContaining({
-                    'filters.startTime': 1000,
-                    'filters.endTime': 2000,
+                    'filters.timeStart': 1000,
+                    'filters.timeEnd': 2000,
                     searchKey: 'test',
                 }),
                 undefined
@@ -123,6 +123,22 @@ describe('LogOperations', () => {
 
             expect(mockRequest.get).toHaveBeenCalledWith('/openapi/v1/test-omadac/logs/alerts', { page: 1, pageSize: 10 }, undefined);
             expect(result.data).toHaveLength(1);
+        });
+
+        it('should include optional filters for global alerts', async () => {
+            vi.mocked(mockRequest.get).mockResolvedValue(makePaginatedResponse());
+
+            await logOps.listGlobalAlerts({ page: 1, pageSize: 10, startTime: 1000, endTime: 2000, searchKey: 'test' });
+
+            expect(mockRequest.get).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    'filters.timeStart': 1000,
+                    'filters.timeEnd': 2000,
+                    searchKey: 'test',
+                }),
+                undefined
+            );
         });
     });
 
@@ -214,7 +230,7 @@ describe('LogOperations', () => {
             await logOps.listSiteAlerts({ page: 1, pageSize: 10, startTime: 1640000000000, endTime: 1640100000000, searchKey: 'test' }, 'site-123');
             expect(mockRequest.get).toHaveBeenCalledWith(
                 '/openapi/v1/test-omadac/sites/site-123/logs/alerts',
-                { page: 1, pageSize: 10, 'filters.startTime': 1640000000000, 'filters.endTime': 1640100000000, searchKey: 'test' },
+                { page: 1, pageSize: 10, 'filters.timeStart': 1640000000000, 'filters.timeEnd': 1640100000000, searchKey: 'test' },
                 undefined
             );
         });


### PR DESCRIPTION
## Summary
- `listSiteEvents`, `listSiteAlerts`, `listGlobalEvents`, and `listGlobalAlerts` were sending `filters.startTime`/`filters.endTime` as query params, but the Omada API (per `docs/openapi/10-log.json`) expects `filters.timeStart`/`filters.timeEnd`, and treats them as **required** alongside `page`/`pageSize`.
- This meant all four endpoints always returned an error from the controller, with or without a time filter supplied — confirmed against a live Omada Controller 6.x (OC200 hardware controller).
- Renamed the query params in `src/omadaClient/log.ts` to match the spec, and made `startTime`/`endTime` required in the corresponding tool schemas so callers can't omit them and hit the same 400.
- Left `listSiteAuditLogs`/`listGlobalAuditLogs` untouched — those use a different filter shape (`filters.times` as a JSON array, optional) per the spec, which is a separate issue from what's described in #92.

Fixes #92

## Test plan
- [x] `npm run check` (Biome lint + tsc)
- [x] `npm run build`
- [x] `npm run test:coverage` — 358 files / 2109 tests passing, 93.33% global branch coverage
- [x] `node scripts/check-tool-tests.mjs` and `node scripts/check-readme-sync.mjs` pass
- [x] Manually verified against a live Omada Controller 6.x (OC200) via the MCP server — `listSiteAlerts`/`listSiteEvents` now return data instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)